### PR TITLE
Use a project access token for mirroring

### DIFF
--- a/.github/workflows/lrz-gitlab-mirror.yml
+++ b/.github/workflows/lrz-gitlab-mirror.yml
@@ -1,4 +1,4 @@
-name: GitHub-LRZ_GitLab Mirror
+name: GitHub-to-LRZ-GitLab Mirror (Project Token)
 
 on:
   push:
@@ -13,13 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone repo as bare
+      - name: Clone GitHub repo as bare
         run: |
           git clone --bare https://github.com/exasim-project/FoamAdapter.git
 
       - name: Push to LRZ GitLab (mirror)
         env:
-          GITLAB_PAT: ${{ secrets.GITLAB_PAT }}
+          GITLAB_TOKEN_NAME: "github-mirror-token"           
+          GITLAB_PROJECT_TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}
         run: |
           cd FoamAdapter.git
-          git push --mirror https://oauth2:${GITLAB_PAT}@gitlab-ce.lrz.de/greole/foamadapter.git
+          git push --mirror https://${GITLAB_TOKEN_NAME}:${GITLAB_PROJECT_TOKEN}@gitlab-ce.lrz.de/greole/foamadapter.git


### PR DESCRIPTION
Use a project access token instead of a personal access token for mirroring the GitHub repo to LRZ GitLab 
Then the mirroring job will not tied to a personal account on LRZ GitLab.