### PR TITLE
Disable the building of benchmarks in the triggered CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,7 +146,8 @@ build-and-test-foamadapter-triggered:
     # Step 2: Build FoamAdapter
     # -------------------------
     - echo "Building FoamAdapter against NeoN..."
-    - cmake --preset develop -DFOAMADAPTER_NEON_DIR=../NeoN -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
+    - cmake --preset develop -DFOAMADAPTER_NEON_DIR=../NeoN -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF -DFOAMADAPTER_BUILD_BENCHMARKS=OFF
+
     - cmake --build --preset develop
     # -------------------------
     # Step 3: Run Tests


### PR DESCRIPTION
The current triggered CI job  is used to check if changes in NeoN work for FoamAdapter. For this purpose, it builds FoamAdapter's tests. In addition, it also builds FoamAdapter benchmarks. However, we do not need benchmarks in the CI job.