### PR TITLE
Make LRZ CI triggerd from FoamAdapter and NeoN GitHub separately

### DIFF
--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   trigger-lrz-ci:
     name: Trigger and run CI on GPU (${{ github.event.repository.name }})

--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -50,10 +50,10 @@ jobs:
           git reset --hard origin/${{ steps.branch.outputs.branch }}
           git push --force lrz HEAD:refs/heads/${{ steps.branch.outputs.branch }}
 
-      - name: Cancel running/pending LRZ GitLab CI pipelines
+      - name: Cancel running/pending LRZ GitLab CI pipelines (only when NEON_BRANCH=null)
         run: |
           BRANCH=${{ steps.branch.outputs.branch }}
-          echo "Canceling running/pending CI pipelines for branch $BRANCH"
+          echo "Checking running/pending CI pipelines for branch $BRANCH"
 
           response=$(curl -s -w "%{http_code}" -o response.json \
             --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}" \
@@ -74,14 +74,25 @@ jobs:
 
           pipeline_ids=$(jq -r '.[] | select(.status=="running" or .status=="pending") | .id' response.json)
           if [ -z "$pipeline_ids" ]; then
-            echo "No running/pending CI pipelines to cancel"
+            echo "No running/pending CI pipelines to check"
           else
             for id in $pipeline_ids; do
-              echo "Canceling CI pipeline $id"
-              curl -s --request POST \
+              echo "Checking pipeline $id for NEON_BRANCH"
+              vars=$(curl -s \
                 --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}" \
-                "https://${{ env.LRZ_HOST }}/api/v4/projects/${{ env.LRZ_GROUP }}%2F${{ env.REPO_NAME }}/pipelines/$id/cancel"
-            done
+                "https://${{ env.LRZ_HOST }}/api/v4/projects/${{ env.LRZ_GROUP }}%2F${{ env.REPO_NAME }}/pipelines/$id/variables")
+
+              neon_branch=$(echo "$vars" | jq -r '.[] | select(.key=="NEON_BRANCH") | .value' || true)
+
+              if [ -z "$neon_branch" ] || [ "$neon_branch" == "null" ]; then
+                echo "Canceling pipeline $id (NEON_BRANCH is null/missing)"
+                curl -s --request POST \
+                 --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}" \
+                 "https://${{ env.LRZ_HOST }}/api/v4/projects/${{ env.LRZ_GROUP }}%2F${{ env.REPO_NAME }}/pipelines/$id/cancel"
+              else
+               echo "Keeping pipeline $id (NEON_BRANCH=$neon_branch)"
+              fi
+           done
           fi
 
       - name: Trigger LRZ GitLab CI pipeline

--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -88,8 +88,8 @@ jobs:
 
               neon_branch=$(echo "$vars" | jq -r '.[] | select(.key=="NEON_BRANCH") | .value' || true)
 
-              if [ -z "$neon_branch" ] || [ "$neon_branch" == "null" ]; then
-                echo "Canceling pipeline $id (NEON_BRANCH is null/missing)"
+              if [ "$neon_branch" == "null" ]; then
+                echo "Canceling pipeline $id (NEON_BRANCH is null)"
                 curl -s --request POST \
                  --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}" \
                  "https://${{ env.LRZ_HOST }}/api/v4/projects/${{ env.LRZ_GROUP }}%2F${{ env.REPO_NAME }}/pipelines/$id/cancel"
@@ -108,7 +108,6 @@ jobs:
           response=$(curl -s --request POST \
             --form "token=${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}" \
             --form "ref=$BRANCH" \
-            --form "variables[GITHUB_SHA]=$GITHUB_SHA" \
             "https://${{ env.LRZ_HOST }}/api/v4/projects/${{ env.LRZ_GROUP }}%2F${{ env.REPO_NAME }}/trigger/pipeline")
 
           echo "$response" | jq .

--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -142,11 +142,7 @@ jobs:
                  echo "$PROJECT CI pipeline finished with status: $status"
                  return 1
                   ;;
-               *)
-                 echo "$PROJECT CI pipeline still running..."
-                  ;;
               esac
-
               sleep 60
             done
 

--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -50,10 +50,10 @@ jobs:
           git reset --hard origin/${{ steps.branch.outputs.branch }}
           git push --force lrz HEAD:refs/heads/${{ steps.branch.outputs.branch }}
 
-      - name: Cancel running/pending LRZ GitLab pipelines
+      - name: Cancel running/pending LRZ GitLab CI pipelines
         run: |
           BRANCH=${{ steps.branch.outputs.branch }}
-          echo "Canceling running/pending pipelines for branch $BRANCH"
+          echo "Canceling running/pending CI pipelines for branch $BRANCH"
 
           response=$(curl -s -w "%{http_code}" -o response.json \
             --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}" \
@@ -74,21 +74,21 @@ jobs:
 
           pipeline_ids=$(jq -r '.[] | select(.status=="running" or .status=="pending") | .id' response.json)
           if [ -z "$pipeline_ids" ]; then
-            echo "No running/pending pipelines to cancel"
+            echo "No running/pending CI pipelines to cancel"
           else
             for id in $pipeline_ids; do
-              echo "Canceling pipeline $id"
+              echo "Canceling CI pipeline $id"
               curl -s --request POST \
                 --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}" \
                 "https://${{ env.LRZ_HOST }}/api/v4/projects/${{ env.LRZ_GROUP }}%2F${{ env.REPO_NAME }}/pipelines/$id/cancel"
             done
           fi
 
-      - name: Trigger LRZ GitLab pipeline
+      - name: Trigger LRZ GitLab CI pipeline
         id: trigger
         run: |
           BRANCH=${{ steps.branch.outputs.branch }}
-          echo "Triggering new pipeline on branch $BRANCH"
+          echo "Triggering new CI pipeline on branch $BRANCH"
 
           response=$(curl -s --request POST \
             --form "token=${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}" \
@@ -99,13 +99,13 @@ jobs:
           echo "$response" | jq .
           pipeline_id=$(echo "$response" | jq -r '.id')
           if [ "$pipeline_id" = "null" ] || [ -z "$pipeline_id" ]; then
-            echo "Failed to trigger LRZ pipeline"
+            echo "Failed to trigger LRZ CI pipeline"
             exit 1
           fi
 
           echo "pipeline_id=$pipeline_id" >> $GITHUB_OUTPUT
 
-      - name: Wait for LRZ GitLab pipeline
+      - name: Wait for LRZ GitLab CI pipeline
         run: |
           pipeline_id=${{ steps.trigger.outputs.pipeline_id }}
           echo "Waiting for LRZ pipeline $pipeline_id to finish..."
@@ -119,24 +119,24 @@ jobs:
               "https://${{ env.LRZ_HOST }}/api/v4/projects/${{ env.LRZ_GROUP }}%2F${{ env.REPO_NAME }}/pipelines/$pipeline_id" \
               | jq -r '.status')
 
-            echo "[$i] Pipeline status: $status"
+            echo "[$i] CI pipeline status: $status"
 
             case "$status" in
               ${SUCCESS_STATUSES[*]})
-                echo "LRZ pipeline succeeded"
+                echo "LRZ CI pipeline succeeded"
                 exit 0
                 ;;
               ${FAILURE_STATUSES[*]})
-                echo "LRZ pipeline finished with status: $status"
+                echo "LRZ CI pipeline finished with status: $status"
                 exit 1
                 ;;
               *)
-                echo "LRZ pipeline still running..."
+                echo "LRZ CI pipeline still running..."
                 ;;
             esac
 
             sleep 60
           done
 
-          echo "Timed out after 24h waiting for LRZ pipeline"
+          echo "Timed out after 24h waiting for LRZ CI pipeline"
           exit 1

--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -5,6 +5,9 @@ on:
     branches: [dev, main]
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  schedule:
+    - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+  workflow_dispatch:      # Optional: allows manual trigger
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -124,6 +127,12 @@ jobs:
             local PIPELINE_ID=$2
             local SUCCESS_STATUSES=("success")
             local FAILURE_STATUSES=("failed" "canceled" "skipped")
+
+            # Construct pipeline URL
+            local pipeline_url="https://${{ env.LRZ_HOST }}/${{ env.LRZ_GROUP }}/$PROJECT/-/pipelines/$PIPELINE_ID"
+
+            # Print clickable link in logs
+            echo "Monitoring LRZ GitLab CI pipeline: $pipeline_url"
 
             for i in $(seq 1 $MAX_WAIT_MINUTES); do
               status=$(curl -s \

--- a/.github/workflows/gitlab-ci.yaml
+++ b/.github/workflows/gitlab-ci.yaml
@@ -23,6 +23,7 @@ jobs:
       LRZ_GROUP: greole
       LRZ_HOST: gitlab-ce.lrz.de
       REPO_NAME: ${{ github.event.repository.name }}
+      MAX_WAIT_MINUTES: 1440  # 24 hours
 
     steps:
       - name: Checkout repository
@@ -118,36 +119,39 @@ jobs:
 
       - name: Wait for LRZ GitLab CI pipeline
         run: |
-          pipeline_id=${{ steps.trigger.outputs.pipeline_id }}
-          echo "Waiting for LRZ pipeline $pipeline_id to finish..."
+          wait_pipeline() {
+            local PROJECT=$1
+            local PIPELINE_ID=$2
+            local SUCCESS_STATUSES=("success")
+            local FAILURE_STATUSES=("failed" "canceled" "skipped")
 
-          SUCCESS_STATUSES=("success")
-          FAILURE_STATUSES=("failed" "canceled" "skipped")
+            for i in $(seq 1 $MAX_WAIT_MINUTES); do
+              status=$(curl -s \
+               --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}" \
+               "https://${{ env.LRZ_HOST }}/api/v4/projects/${{ env.LRZ_GROUP }}%2F${{ env.REPO_NAME }}/pipelines/$PIPELINE_ID" \
+                | jq -r '.status')
 
-          for i in {1..1440}; do
-            status=$(curl -s \
-              --header "PRIVATE-TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}" \
-              "https://${{ env.LRZ_HOST }}/api/v4/projects/${{ env.LRZ_GROUP }}%2F${{ env.REPO_NAME }}/pipelines/$pipeline_id" \
-              | jq -r '.status')
+              echo "[$i] $PROJECT pipeline status: $status"
 
-            echo "[$i] CI pipeline status: $status"
+             case "$status" in
+               ${SUCCESS_STATUSES[*]})
+                  echo "$PROJECT CI pipeline succeeded"
+                 return 0
+                 ;;
+                ${FAILURE_STATUSES[*]})
+                 echo "$PROJECT CI pipeline finished with status: $status"
+                 return 1
+                  ;;
+               *)
+                 echo "$PROJECT CI pipeline still running..."
+                  ;;
+              esac
 
-            case "$status" in
-              ${SUCCESS_STATUSES[*]})
-                echo "LRZ CI pipeline succeeded"
-                exit 0
-                ;;
-              ${FAILURE_STATUSES[*]})
-                echo "LRZ CI pipeline finished with status: $status"
-                exit 1
-                ;;
-              *)
-                echo "LRZ CI pipeline still running..."
-                ;;
-            esac
+              sleep 60
+            done
 
-            sleep 60
-          done
+            echo "Timed out after $MAX_WAIT_MINUTES minutes waiting for $PROJECT CI pipeline"
+            return 1
+          }
 
-          echo "Timed out after 24h waiting for LRZ CI pipeline"
-          exit 1
+          wait_pipeline "${{ env.REPO_NAME }}" "${{ steps.trigger.outputs.pipeline_id }}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,7 +106,7 @@ build-and-test-with-neon-feature:
     # -------------------------
     # Step 1: Prepare NeoN
     # -------------------------
-    - echo "Triggered by NeoN CI pipeline => Use NeoN branch=$NEON_BRANCH
+    - echo "Triggered by NeoN CI pipeline => Use NeoN branch=$NEON_BRANCH"
     - git clone --depth 1 --single-branch --branch $NEON_BRANCH https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
     # -------------------------
     # Step 2: Build FoamAdapter

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ build-and-test-foamadapter:
   <<: *build-foamadapter-common
   rules:
     # Run only when triggered via API
-    - if: $CI_PIPELINE_SOURCE == "trigger"
+    - if: '$CI_PIPELINE_SOURCE == "trigger" && !$NEON_COMMIT && !$NEON_BRANCH'
       when: always
     # Skip in all other cases
     - when: never
@@ -94,7 +94,7 @@ build-and-test-foamadapter-triggered:
   <<: *build-foamadapter-common
   rules:
     # Run only if NeoN pipeline triggered this one (the variables are passed from NeoN pipeline)
-    - if: '$NEON_COMMIT || $NEON_BRANCH'
+    - if: '$NEON_COMMIT && $NEON_BRANCH'
       when: always
 
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,7 +116,7 @@ build-and-test-foamadapter-with-neon-features:
     # Step 2: Build FoamAdapter
     # -------------------------
     - echo "Building FoamAdapter against NeoN..."
-    - cmake --preset develop -DFOAMADAPTER_NEON_DIR=../NeoN -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
+    - cmake --preset develop -DFOAMADAPTER_NEON_DIR=../NeoN -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF -DFOAMADAPTER_BUILD_BENCHMARKS=OFF
     - cmake --build --preset develop
     # -------------------------
     # Step 3: Run Tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,10 +106,6 @@ build-and-test-foamadapter-with-neon-features:
     - echo "NeoN triggered with branch=$NEON_BRANCH commit=$NEON_COMMIT"
     - echo "Using FoamAdapter branch=$FOAMADAPTER_BRANCH"
 
-    # Switch to that branch
-    - git fetch origin "$FOAMADAPTER_BRANCH"
-    - git checkout -B "$FOAMADAPTER_BRANCH" origin/$FOAMADAPTER_BRANCH
-
     # -------------------------
     # Step 1: Prepare NeoN
     # -------------------------

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,15 +128,17 @@ build-and-test-foamadapter-with-neon-features:
     # -------------------------
     - echo "Triggered by NeoN CI pipeline => Use NeoN branch=$NEON_BRANCH commit=$NEON_COMMIT"
     - |
-      if [ -n "$NEON_COMMIT" ]; then
-        git clone https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
-        cd ../NeoN
-        git fetch origin $NEON_COMMIT --depth 1
-        git checkout $NEON_COMMIT
-        cd -
-      else
-        git clone --depth 1 --branch ${NEON_BRANCH:-main} https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
-      fi
+      # if [ -n "$NEON_COMMIT" ]; then
+      #   git clone https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
+      #   cd ../NeoN
+      #   git fetch origin $NEON_COMMIT --depth 1
+      #   git checkout $NEON_COMMIT
+      #   cd -
+      # else
+      #   git clone --depth 1 --branch ${NEON_BRANCH:-main} https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
+      # fi
+
+    - git clone --depth 1 --branch $NEON_BRANCH https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
     # -------------------------
     # Step 2: Build FoamAdapter
     # -------------------------

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ build-and-test-foamadapter-with-neon-main:
   <<: *build-foamadapter-common
   rules:
     # Run only when triggered via API from FoamAdapter GitHub CI
-    - if: $CI_PIPELINE_SOURCE == "trigger" && $NEON_COMMIT == null && $NEON_BRANCH == null
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $NEON_BRANCH == null
       when: always
     # Skip in all other cases
     - when: never
@@ -94,7 +94,7 @@ build-and-test-foamadapter-with-neon-features:
   <<: *build-foamadapter-common
   rules:
     # Run only when triggered via API from NeoN GitHub CI
-    - if: $CI_PIPELINE_SOURCE == "trigger" && $NEON_COMMIT != null && $NEON_BRANCH != null
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $NEON_BRANCH != null
       when: always
     # Skip in all other cases
     - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ variables:
     - nvidia-smi
     - nvcc --version
 
-build-and-test-foamadapter-with-neon-main:
+build-and-test-with-neon-main:
   <<: *build-foamadapter-common
   rules:
     # Run only when triggered via API from FoamAdapter GitHub CI
@@ -76,12 +76,15 @@ build-and-test-foamadapter-with-neon-main:
     # Step 1: Prepare NeoN
     # -------------------------
     - echo "Default FoamAdapter CI pipeline => Use NeoN branch=main"
-    - git clone --depth 1 --branch main https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
+    - git clone --depth 1 --single-branch --branch main https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
     # -------------------------
     # Step 2: Build FoamAdapter
     # -------------------------
     - echo "Building FoamAdapter against NeoN..."
-    - cmake --preset develop -DFOAMADAPTER_NEON_DIR=../NeoN -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF -DFOAMADAPTER_BUILD_BENCHMARKS=OFF
+    - |
+      cmake --preset develop -DFOAMADAPTER_NEON_DIR=../NeoN \
+      -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF \
+      -DFOAMADAPTER_BUILD_BENCHMARKS=OFF
     - cmake --build --preset develop
     # -------------------------
     # Step 3: Run Tests
@@ -90,7 +93,7 @@ build-and-test-foamadapter-with-neon-main:
     - ctest --preset develop --output-on-failure
 
 
-build-and-test-foamadapter-with-neon-features:
+build-and-test-with-neon-feature:
   <<: *build-foamadapter-common
   rules:
     # Run only when triggered via API from NeoN GitHub CI
@@ -100,23 +103,19 @@ build-and-test-foamadapter-with-neon-features:
     - when: never
 
   script:
-    # ----------------------------------
-    # Step 0: Select FoamAdapter branch
-    # ----------------------------------
-    - echo "NeoN triggered with branch=$NEON_BRANCH commit=$NEON_COMMIT"
-    - echo "Using FoamAdapter branch=$FOAMADAPTER_BRANCH"
-
     # -------------------------
     # Step 1: Prepare NeoN
     # -------------------------
-    - echo "Triggered by NeoN CI pipeline => Use NeoN branch=$NEON_BRANCH commit=$NEON_COMMIT"
-    - git clone --depth 1 --branch $NEON_BRANCH https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
-    # - git clone --depth 1 --branch main https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
+    - echo "Triggered by NeoN CI pipeline => Use NeoN branch=$NEON_BRANCH
+    - git clone --depth 1 --single-branch --branch $NEON_BRANCH https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
     # -------------------------
     # Step 2: Build FoamAdapter
     # -------------------------
     - echo "Building FoamAdapter against NeoN..."
-    - cmake --preset develop -DFOAMADAPTER_NEON_DIR=../NeoN -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF -DFOAMADAPTER_BUILD_BENCHMARKS=OFF
+    - |
+      cmake --preset develop -DFOAMADAPTER_NEON_DIR=../NeoN \
+       -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF \
+       -DFOAMADAPTER_BUILD_BENCHMARKS=OFF
     - cmake --build --preset develop
     # -------------------------
     # Step 3: Run Tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,42 +103,18 @@ build-and-test-foamadapter-with-neon-features:
     # ----------------------------------
     # Step 0: Select FoamAdapter branch
     # ----------------------------------
-    - |
-      echo "NeoN triggered with branch=$NEON_BRANCH commit=$NEON_COMMIT"
-      # Default branch fallback
-      FOAMADAPTER_BRANCH="main"
+    - echo "NeoN triggered with branch=$NEON_BRANCH commit=$NEON_COMMIT"
+    - echo "Using FoamAdapter branch=$FOAMADAPTER_BRANCH"
 
-      if [ -n "$NEON_BRANCH" ]; then
-        echo "Checking if FoamAdapter branch $NEON_BRANCH exists..."
-        if git ls-remote --exit-code --heads origin "$NEON_BRANCH"; then
-          FOAMADAPTER_BRANCH="$NEON_BRANCH"
-          echo "Found matching FoamAdapter branch: $FOAMADAPTER_BRANCH"
-        else
-          echo "No matching branch, falling back to main"
-        fi
-      fi
-
-      echo "Using FoamAdapter branch: $FOAMADAPTER_BRANCH"
-
-      # Switch to that branch
-      git fetch origin "$FOAMADAPTER_BRANCH"
-      git checkout "$FOAMADAPTER_BRANCH"
+    # Switch to that branch
+    - git fetch origin "$FOAMADAPTER_BRANCH"
+    - git checkout "$FOAMADAPTER_BRANCH"
     # -------------------------
     # Step 1: Prepare NeoN
     # -------------------------
     - echo "Triggered by NeoN CI pipeline => Use NeoN branch=$NEON_BRANCH commit=$NEON_COMMIT"
-    - |
-      # if [ -n "$NEON_COMMIT" ]; then
-      #   git clone https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
-      #   cd ../NeoN
-      #   git fetch origin $NEON_COMMIT --depth 1
-      #   git checkout $NEON_COMMIT
-      #   cd -
-      # else
-      #   git clone --depth 1 --branch ${NEON_BRANCH:-main} https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
-      # fi
-
     - git clone --depth 1 --branch $NEON_BRANCH https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
+    # - git clone --depth 1 --branch main https://gitlab-ce.lrz.de/greole/neon.git ../NeoN
     # -------------------------
     # Step 2: Build FoamAdapter
     # -------------------------

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,11 +62,11 @@ variables:
     - nvidia-smi
     - nvcc --version
 
-build-and-test-foamadapter:
+build-and-test-foamadapter-with-neon-main:
   <<: *build-foamadapter-common
   rules:
-    # Run only when triggered via API
-    - if: $CI_PIPELINE_SOURCE == "trigger" && !$NEON_COMMIT && !$NEON_BRANCH
+    # Run only when triggered via API from FoamAdapter GitHub CI
+    - if: '$CI_PIPELINE_SOURCE == "trigger" && !NEON_COMMIT && !NEON_BRANCH'
       when: always
     # Skip in all other cases
     - when: never
@@ -90,12 +90,14 @@ build-and-test-foamadapter:
     - ctest --preset develop --output-on-failure
 
 
-build-and-test-foamadapter-triggered:
+build-and-test-foamadapter-with-neon-features:
   <<: *build-foamadapter-common
   rules:
-    # Run only if NeoN pipeline triggered this one (the variables are passed from NeoN pipeline)
-    - if: '$NEON_COMMIT && $NEON_BRANCH'
+    # Run only when triggered via API from NeoN GitHub CI
+    - if: '$CI_PIPELINE_SOURCE == "trigger" && NEON_COMMIT && NEON_BRANCH'
       when: always
+    # Skip in all other cases
+    - when: never
 
   script:
     # ----------------------------------

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,7 +108,8 @@ build-and-test-foamadapter-with-neon-features:
 
     # Switch to that branch
     - git fetch origin "$FOAMADAPTER_BRANCH"
-    - git checkout "$FOAMADAPTER_BRANCH"
+    - git checkout -B "$FOAMADAPTER_BRANCH" "origin/$FOAMADAPTER_BRANCH"
+
     # -------------------------
     # Step 1: Prepare NeoN
     # -------------------------

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,7 +108,7 @@ build-and-test-foamadapter-with-neon-features:
 
     # Switch to that branch
     - git fetch origin "$FOAMADAPTER_BRANCH"
-    - git checkout -B "$FOAMADAPTER_BRANCH" "origin/$FOAMADAPTER_BRANCH"
+    - git checkout -B "$FOAMADAPTER_BRANCH" origin/$FOAMADAPTER_BRANCH
 
     # -------------------------
     # Step 1: Prepare NeoN

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ build-and-test-foamadapter:
   <<: *build-foamadapter-common
   rules:
     # Run only when triggered via API
-    - if: '$CI_PIPELINE_SOURCE == "trigger" && !$NEON_COMMIT && !$NEON_BRANCH'
+    - if: $CI_PIPELINE_SOURCE == "trigger" && !$NEON_COMMIT && !$NEON_BRANCH
       when: always
     # Skip in all other cases
     - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ build-and-test-foamadapter-with-neon-main:
   <<: *build-foamadapter-common
   rules:
     # Run only when triggered via API from FoamAdapter GitHub CI
-    - if: '$CI_PIPELINE_SOURCE == "trigger" && !NEON_COMMIT && !NEON_BRANCH'
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $NEON_COMMIT == null && $NEON_BRANCH == null
       when: always
     # Skip in all other cases
     - when: never
@@ -94,7 +94,7 @@ build-and-test-foamadapter-with-neon-features:
   <<: *build-foamadapter-common
   rules:
     # Run only when triggered via API from NeoN GitHub CI
-    - if: '$CI_PIPELINE_SOURCE == "trigger" && NEON_COMMIT && NEON_BRANCH'
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $NEON_COMMIT != null && $NEON_BRANCH != null
       when: always
     # Skip in all other cases
     - when: never


### PR DESCRIPTION
The current status:
FoamAdapter LRZ GitLab CI can be triggered from two places:
1. from FoamAdapter GitHub CI for changes to FoamAdapter repo
2. from NeoN LRZ GitLab CI for changes to NeoN repo

The changes that this PR makes:
1. For changes to NeoN repo, FoamAdapter LRZ GitLab is triggered from NeoN GitHUb CI.
2. FoamAdapter GitHub CI cancels only the running or pending LRZ GitLab CI pipelines triggered from FoamAdapter GitHub CI, but not LRZ GitLab CI pipelines triggered from NeoN GitHub CI.
3. FoamAdapter LRZ GitLab CI jobs copy only the latest commit of a given branch of NeoN.

**Note**:
This PR needs to work with [another PR](https://github.com/exasim-project/NeoN/pull/358) on NeoN GitHub.