### PR TITLE
Test diagonal and upper triangular matrix coefficients in pressureVelocityCoupling test

### DIFF
--- a/benchmarks/explicitOperators.cpp
+++ b/benchmarks/explicitOperators.cpp
@@ -205,7 +205,7 @@ TEST_CASE("GradOperator")
             {
                 NeoN::fill(nfGradT.internalVector(), NeoN::Vec3(0, 0, 0));
                 NeoN::fill(nfGradT.boundaryData().value(), NeoN::Vec3(0, 0, 0));
-                fvcc::GaussGreenGrad(exec, nfMesh).grad(nfT, NeoN::dsl::Coeff(), nfGradT);
+                fvcc::GaussGreenGrad(exec, nfMesh).grad(nfT, nfGradT, NeoN::dsl::Coeff());
                 NeoN::fence(exec);
                 return;
             };

--- a/test/catch2/common.hpp
+++ b/test/catch2/common.hpp
@@ -38,4 +38,12 @@ struct ApproxVector
             && Catch::Approx(0).margin(margin[1]) == diff[1]
             && Catch::Approx(0).margin(margin[2]) == diff[2];
     }
+    bool operator()(NeoN::Vec3 rhs, Foam::scalar lhs) const
+    {
+        NeoN::Vec3 diff(rhs[0] - lhs, rhs[1] - lhs, rhs[2] - lhs);
+
+        return Catch::Approx(0).margin(margin[0]) == diff[0]
+            && Catch::Approx(0).margin(margin[1]) == diff[1]
+            && Catch::Approx(0).margin(margin[2]) == diff[2];
+    }
 };

--- a/test/test_pressureVelocityCoupling.cpp
+++ b/test/test_pressureVelocityCoupling.cpp
@@ -95,6 +95,9 @@ TEST_CASE("PressureVelocityCoupling")
             ApproxVector(1e-15)
         );
 
+        // NeoN stores boundary diagonal contributions directly in the matrix, whereas
+        // OpenFOAM keeps them separate. Remove them before comparing against OpenFOAM
+        // coefficients.
         nf::compare(
             NeoN::la::removeBoundaryContributions(nfUEqn.linearSystem()).matrix().diag(),
             ofUEqn.diag(),

--- a/test/test_pressureVelocityCoupling.cpp
+++ b/test/test_pressureVelocityCoupling.cpp
@@ -49,6 +49,7 @@ TEST_CASE("PressureVelocityCoupling")
         ),
         fvc::flux(ofU)
     );
+    ofPhi.correctBoundaryConditions();
 
     Foam::surfaceScalarField ofNu(
         Foam::IOobject(
@@ -61,6 +62,7 @@ TEST_CASE("PressureVelocityCoupling")
         mesh,
         Foam::dimensionedScalar("nu", Foam::dimensionSet(0, 2, -1, 0, 0), 0.01)
     );
+    ofNu.correctBoundaryConditions();
 
     auto nfPhi = NeoFOAM::constructFrom(rt.exec, rt.nfMesh, ofPhi);
     auto nfNu = NeoFOAM::constructFrom(rt.exec, rt.nfMesh, ofNu);
@@ -86,6 +88,19 @@ TEST_CASE("PressureVelocityCoupling")
 
         Foam::volScalarField forAU("rAU", 1.0 / ofUEqn.A());
         nfUEqn.assemble();
+
+        nf::compare(
+            NeoN::la::upper(nfUEqn.linearSystem().matrix()),
+            ofUEqn.upper(),
+            ApproxVector(1e-15)
+        );
+
+        nf::compare(
+            NeoN::la::removeBoundaryContributions(nfUEqn.linearSystem()).matrix().diag(),
+            ofUEqn.diag(),
+            ApproxVector(1e-15)
+        );
+
         auto nfrAU = nf::computeRAU(nfUEqn);
 
         NeoFOAM::compare(nfrAU, forAU, ApproxScalar(1e-15), true);


### PR DESCRIPTION
This PR is the counterpart to https://github.com/exasim-project/NeoN/pull/495 and adds a test to the pressureVelocityCoupling tests to ensure the correctness of the diagonal and upper triangular matrix coefficients.

Additionally: 
- fix order of arguments for the explicit grad benchmark