### PR TITLE
Read cellProcAddressing in meshAdapter and verify it in distributed test

### DIFF
--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -88,6 +88,7 @@ elif [[ "$GPU_VENDOR" == "intel" ]]; then
         -DKokkos_ARCH_INTEL_PVC=ON \
         -DNeoN_WITH_THREADS=OFF \
         -DNeoN_WITH_MPI=OFF \
+        -DNEOFOAM_WITH_MPI=OFF \
         -DCMAKE_BUILD_TYPE="release" \
         -DNEOFOAM_BUILD_BENCHMARKS=ON
 fi

--- a/examples/neoIcoFoam/neoIcoFoam.cpp
+++ b/examples/neoIcoFoam/neoIcoFoam.cpp
@@ -60,8 +60,6 @@ int main(int argc, char* argv[])
         auto& phi = nf::constructAndRegister(vectorCollection, rt, ofPhi, false);
         NeoN::scalar cumulativeContErr = 0.0;
 
-        auto commPattern = createCommunicationPattern(rt);
-
         // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
         NeoN::Logging::info("Starting time loop");

--- a/include/NeoFOAM/auxiliary/readers.hpp
+++ b/include/NeoFOAM/auxiliary/readers.hpp
@@ -128,7 +128,6 @@ auto readVolBoundaryConditions(const NeoN::UnstructuredMesh& nfMesh, const FoamT
 
     int patchi = 0;
     std::vector<fvcc::VolumeBoundary<type_primitive_t>> bcs;
-    NeoN::mpi::Environment mpiEnv;
     // do non processor first
     for (const auto bName : bDict.toc())
     {

--- a/include/NeoFOAM/datastructures/pdeSolver.hpp
+++ b/include/NeoFOAM/datastructures/pdeSolver.hpp
@@ -91,11 +91,13 @@ public:
             // needed; the rank-0 convention is the only one neoIcoFoam currently
             // uses, and this matches what OpenFOAM's processorPolyPatch /
             // fvMatrix::setReference do internally.
+#ifdef NF_WITH_MPI_SUPPORT
             NeoN::mpi::Environment mpiEnv;
             if (mpiEnv.isInitialized() && mpiEnv.rank() != 0)
             {
                 return;
             }
+#endif
 
             const auto rowOffs = ls.matrix().sparsity()->rowOffs().view();
             const auto diagOffset = ls.faceToMatrixAddress()->diagOffset().view();
@@ -136,6 +138,7 @@ public:
         // sentinel -1, which would compare unequal to 0 if cast to size_t)
         // and on rank 0 in parallel. SetReference::operator() further guards
         // the matrix mutation against non-rank-0 in initialised MPI.
+#ifdef NF_WITH_MPI_SUPPORT
         const auto& mpiEnv = runTime_.mpiEnvironment;
         if (!mpiEnv.isInitialized() || mpiEnv.rank() == 0)
         {
@@ -143,6 +146,11 @@ public:
             pRefCell_ = pRefCell;
             pRefValue_ = pRefValue;
         }
+#else
+        needReference_ = true;
+        pRefCell_ = pRefCell;
+        pRefValue_ = pRefValue;
+#endif
     }
 
     /** @brief assemble the linear system owned by the solver based on the current expression */

--- a/include/NeoFOAM/datastructures/runTime.hpp
+++ b/include/NeoFOAM/datastructures/runTime.hpp
@@ -29,7 +29,9 @@ struct RunTime
     NeoN::Dictionary controlDict;
     NeoN::Dictionary fvSolutionDict;
     NeoN::Dictionary fvSchemesDict;
+#ifdef NF_WITH_MPI_SUPPORT
     NeoN::mpi::Environment mpiEnvironment;
+#endif
 };
 
 
@@ -44,6 +46,8 @@ RegisteredType& readOrCreate(RunTime& runTime, std::string name, InitializerType
     return runTime.controlDict.get<RegisteredType>(name);
 }
 
+#ifdef NF_WITH_MPI_SUPPORT
 NeoN::CommunicationPattern createCommunicationPattern(const RunTime& runTime);
+#endif
 
 } // End namespace NeoFOAM

--- a/src/algorithms/pressureVelocityCoupling.cpp
+++ b/src/algorithms/pressureVelocityCoupling.cpp
@@ -320,42 +320,39 @@ nnfvcc::SurfaceField<scalar> flux(const PDESolver<scalar>& expr)
     const auto [mValue, rhsValue] = views(ls.boundaryMatrix(), ls.boundaryRhs());
     const auto faceCells = mesh.boundaryMesh().faceOwners().view();
 
+    // Boundary fluxes go in faceFlux.boundaryData().value() — faceFlux.internalVector()
+    // only covers internal faces (see updateFaceVelocity for the same pattern).
     NeoN::parallelFor(
         exec,
-        {nInternalFaces, nInternalFaces + nBoundaryFaces},
-        NEON_LAMBDA(const size_t facei) {
-            auto bfacei = facei - nInternalFaces;
+        {0, static_cast<size_t>(nBoundaryFaces)},
+        NEON_LAMBDA(const size_t bfacei) {
             scalar bflux = rhsValue[bfacei] - mValue.values[bfacei] * internalP[faceCells[bfacei]];
-            iFlux[facei] = bflux;
             bFlux[bfacei] = bflux;
         }
     );
 
-    const auto nTotalFaces = faceFlux.internalVector().size();
-    const auto nlValues = ls.offDiagonalMatrix().values().view();
-    const auto pBoundV = p.boundaryData().value().view();
+    // Processor-boundary faces sit at the tail of boundaryData().value() at indices
+    // [nBoundaryFaces, nBoundaryFaces + nProcFaces). faceOwners() is local-index for
+    // both physical and proc faces (BoundaryMesh::nBoundaryFaces excludes proc tail).
+    const auto nProcFaces = mesh.nProcBoundaryFaces();
+    if (nProcFaces > 0)
+    {
+        const auto nlValues = ls.offDiagonalMatrix().values().view();
+        const auto pBoundV = p.boundaryData().value().view();
 
-    NeoN::parallelFor(
-        exec,
-        {nInternalFaces + nBoundaryFaces, nTotalFaces},
-        NEON_LAMBDA(const size_t facei) {
-            // Local-owner of the proc-boundary face. Don't pull from
-            // offDiagonalMatrix() — its rowOffs() returns CSR-style
-            // cumulative offsets (not row indices), and even its rowIdxs()
-            // would carry global cell ids (see createEmptyLinearSystem,
-            // where row entries are faceOwners + globalOffset). The
-            // boundaryMesh's faceOwners view is the local-index source
-            // already used by the physical-boundary loop above.
-            auto bcfaceii = facei - (nInternalFaces + nBoundaryFaces);
-            auto bfacei = facei - nInternalFaces;
-            auto own = static_cast<std::size_t>(faceCells[bfacei]);
-            auto coupling = nlValues[bcfaceii];
-            auto pGhost = pBoundV[bfacei];
-            scalar pflux = coupling * (pGhost - internalP[own]);
-            iFlux[facei] = pflux;
-            bFlux[bfacei] = pflux;
-        }
-    );
+        NeoN::parallelFor(
+            exec,
+            {0, static_cast<size_t>(nProcFaces)},
+            NEON_LAMBDA(const size_t procFacei) {
+                auto bfacei = nBoundaryFaces + procFacei;
+                auto own = static_cast<std::size_t>(faceCells[bfacei]);
+                auto coupling = nlValues[procFacei];
+                auto pGhost = pBoundV[bfacei];
+                scalar pflux = coupling * (pGhost - internalP[own]);
+                bFlux[bfacei] = pflux;
+            }
+        );
+    }
 
     return faceFlux;
 }

--- a/src/auxiliary/setup.cpp
+++ b/src/auxiliary/setup.cpp
@@ -113,7 +113,9 @@ RunTime createAdapterRunTime(const Foam::Time& in, const NeoN::Executor exec)
     NeoN::Logging::info("Creating NeoFOAM runTime");
     std::unique_ptr<MeshAdapter> meshPtr = createMesh(exec, in);
     MeshAdapter& mesh = *meshPtr;
+#ifdef NF_WITH_MPI_SUPPORT
     auto mpiEnvironment = NeoN::mpi::Environment {};
+#endif
 
     auto& nfMesh = mesh.nfMesh();
     return NeoFOAM::RunTime {
@@ -130,7 +132,9 @@ RunTime createAdapterRunTime(const Foam::Time& in, const NeoN::Executor exec)
         .controlDict = convert(in.controlDict()),
         .fvSolutionDict = convert(mesh.solutionDict()),
         .fvSchemesDict = convert(mesh.schemesDict()),
+#ifdef NF_WITH_MPI_SUPPORT
         .mpiEnvironment = mpiEnvironment
+#endif
     };
 }
 

--- a/src/compatibility/fvSolution.cpp
+++ b/src/compatibility/fvSolution.cpp
@@ -113,8 +113,12 @@ void updatePreconditioner(NeoN::Dictionary& solverDict)
     // would be true in those cases too, so we'd wrap the preconditioner in
     // Schwarz for a serial solve and SIGILL inside Ginkgo. Gate the wrap on
     // MPI being initialised AND sizeRank > 1.
+#ifdef NF_WITH_MPI_SUPPORT
     NeoN::mpi::Environment mpiEnv;
     const bool distributed = mpiEnv.isInitialized() && mpiEnv.sizeRank() > 1;
+#else
+    const bool distributed = false;
+#endif
     const auto& activeMap = distributed ? distributedPreconditionerMap : preconditionerMap;
 
     // if no preconditioner is set but smoother switch to BiCGStab with BJ

--- a/src/datastructures/meshAdapter.cpp
+++ b/src/datastructures/meshAdapter.cpp
@@ -169,10 +169,12 @@ int32_t computeNBoundaryFaces(const Foam::fvMesh& mesh)
     return nBoundaryFaces;
 }
 
+#ifdef NF_WITH_MPI_SUPPORT
 NeoN::CommunicationPattern createCommunicationPattern(const RunTime& runTime)
 {
     return NeoN::computeCommunicationPattern(runTime.nfMesh);
 }
+#endif
 
 NeoN::UnstructuredMesh
 readOpenFOAMMesh(const NeoN::Executor exec, const Foam::fvMesh& mesh, bool fullMeshOnGPU)

--- a/src/datastructures/meshAdapter.cpp
+++ b/src/datastructures/meshAdapter.cpp
@@ -9,6 +9,8 @@
 
 #include "processorFvPatch.H"
 #include "lduInterfaceField.H"
+#include "labelIOList.H"
+#include "polyMesh.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -176,6 +178,41 @@ NeoN::CommunicationPattern createCommunicationPattern(const RunTime& runTime)
 }
 #endif
 
+// Reads OpenFOAM's `constant/polyMesh/cellProcAddressing` if present and returns
+// it as a vector of NeoN::localIdx (one entry per local cell, giving the global
+// cell index in the undecomposed mesh). Returns an empty vector if the addressing
+// file is not on disk — typical for serial runs that never went through
+// `decomposePar`, or for synthetic meshes.
+//
+// Only the local rank's own `cellProcAddressing` is read; no MPI calls.
+//
+// The contents feed `UnstructuredMesh::foamGlobalCellIds`, which is purely
+// informational for OF round-tripping (reconstruction, checkpoint loading) and
+// is NOT consumed by NeoN's internal halo communication or by Ginkgo's
+// distributed linear-algebra path. See commPattern audit REVIEW.md H3.
+std::vector<NeoN::localIdx> readFoamGlobalCellIds(const Foam::fvMesh& mesh)
+{
+    Foam::IOobject header(
+        "cellProcAddressing",
+        mesh.facesInstance(),
+        Foam::polyMesh::meshSubDir,
+        mesh,
+        Foam::IOobject::READ_IF_PRESENT,
+        Foam::IOobject::NO_WRITE
+    );
+
+    if (!header.typeHeaderOk<Foam::labelIOList>(true))
+    {
+        return {};
+    }
+
+    Foam::labelIOList foamAddressing(header);
+    std::vector<NeoN::localIdx> result;
+    result.reserve(static_cast<std::size_t>(foamAddressing.size()));
+    forAll(foamAddressing, i) { result.push_back(static_cast<NeoN::localIdx>(foamAddressing[i])); }
+    return result;
+}
+
 NeoN::UnstructuredMesh
 readOpenFOAMMesh(const NeoN::Executor exec, const Foam::fvMesh& mesh, bool fullMeshOnGPU)
 {
@@ -246,7 +283,8 @@ readOpenFOAMMesh(const NeoN::Executor exec, const Foam::fvMesh& mesh, bool fullM
         fromFoamField(exec, magFaceAreas),
         fromFoamField(exec, mesh.faceOwner()),
         fromFoamField(exec, mesh.faceNeighbour()),
-        bMesh
+        bMesh,
+        readFoamGlobalCellIds(mesh)
     );
 
     return uMesh;

--- a/test/setup_snGrad/0/T
+++ b/test/setup_snGrad/0/T
@@ -9,40 +9,14 @@ FoamFile
 {
     version     2.0;
     format      ascii;
-<<<<<<< HEAD:test/setup_pressureVelocityCoupling/processor1/constant/polyMesh/neighbour
-    arch        "LSB;label=32;scalar=64";
-    note        "nPoints:32  nCells:9  nFaces:42  nInternalFaces:12";
-    class       labelList;
-    location    "constant/polyMesh";
-    object      neighbour;
-=======
     class       volScalarField;
     object      T;
->>>>>>> origin/develop:test/setup_snGrad/0/T
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 dimensions      [0 0 0 1 0 0 0];
 
-<<<<<<< HEAD:test/setup_pressureVelocityCoupling/processor1/constant/polyMesh/neighbour
-12
-(
-1
-3
-2
-4
-5
-4
-6
-5
-7
-8
-7
-8
-)
-=======
 internalField   uniform 0;
->>>>>>> origin/develop:test/setup_snGrad/0/T
 
 boundaryField
 {

--- a/test/setup_snGrad/0/U
+++ b/test/setup_snGrad/0/U
@@ -16,45 +16,7 @@ FoamFile
 
 dimensions      [0 1 -1 0 0 0 0];
 
-<<<<<<< HEAD:test/setup_pressureVelocityCoupling/processor0/constant/polyMesh/pointProcAddressing
-32
-(
-0
-1
-4
-5
-8
-9
-12
-13
-16
-17
-20
-21
-24
-25
-28
-29
-32
-33
-36
-37
-40
-41
-44
-45
-48
-49
-52
-53
-56
-57
-60
-61
-)
-=======
 internalField   uniform (0.0 0.0 0.0);
->>>>>>> origin/develop:test/setup_snGrad/0/U
 
 boundaryField
 {

--- a/test/setup_snGrad/constant/transportProperties
+++ b/test/setup_snGrad/constant/transportProperties
@@ -14,10 +14,6 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-<<<<<<< HEAD:test/setup_pressureVelocityCoupling/processor2/constant/polyMesh/boundaryProcAddressing
-4(0 1 2 -1)
-=======
 DT              1e-05;
->>>>>>> origin/develop:test/setup_snGrad/constant/transportProperties
 
 // ************************************************************************* //

--- a/test/setup_snGrad/system/controlDict
+++ b/test/setup_snGrad/system/controlDict
@@ -16,55 +16,7 @@ FoamFile
 
 application     laplacianFoam;
 
-<<<<<<< HEAD:test/setup_pressureVelocityCoupling/processor0/constant/polyMesh/owner
-42
-(
-0
-0
-1
-1
-2
-3
-3
-4
-4
-5
-6
-7
-2
-5
-8
-0
-3
-6
-0
-1
-2
-6
-7
-8
-0
-1
-2
-3
-4
-5
-6
-7
-8
-0
-1
-2
-3
-4
-5
-6
-7
-8
-)
-=======
 startFrom       startTime;
->>>>>>> origin/develop:test/setup_snGrad/system/controlDict
 
 startTime       0;
 

--- a/test/setup_snGrad/system/fvSchemes
+++ b/test/setup_snGrad/system/fvSchemes
@@ -19,59 +19,11 @@ ddtSchemes
     default         Euler;
 }
 
-<<<<<<< HEAD:test/setup_pressureVelocityCoupling/processor0/constant/polyMesh/faceProcAddressing
-42
-(
-2
-3
-10
-11
-18
-23
-24
-31
-32
-39
-44
-49
-55
-56
-57
-64
-65
-66
-73
-74
-75
-82
-83
-84
-100
-101
-102
-103
-104
-105
-106
-107
-108
-1
-9
-17
-22
-30
-38
-43
-48
-53
-)
-=======
 gradSchemes
 {
     default         Gauss linear;
     grad(T)         Gauss linear;
 }
->>>>>>> origin/develop:test/setup_snGrad/system/fvSchemes
 
 divSchemes
 {

--- a/test/setup_snGrad/system/fvSolution
+++ b/test/setup_snGrad/system/fvSolution
@@ -14,9 +14,6 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-<<<<<<< HEAD:test/setup_pressureVelocityCoupling/processor1/constant/polyMesh/cellProcAddressing
-9(1 4 7 10 13 16 19 22 25)
-=======
 solvers
 {
     T
@@ -27,6 +24,5 @@ solvers
         relTol          0;
     }
 }
->>>>>>> origin/develop:test/setup_snGrad/system/fvSolution
 
 // ************************************************************************* //

--- a/test/test_backwardDdtScheme.cpp
+++ b/test/test_backwardDdtScheme.cpp
@@ -23,7 +23,6 @@ TEST_CASE("(backward) ddt implicit matches OpenFOAM", "[ddt][backward]")
 {
     Foam::Time& runTime = *timePtr;
     Foam::argList& args = *argsPtr;
-    NeoN::mpi::Environment mpiEnviron;
 
     NeoN::Database db;
     fvcc::VectorCollection& fieldCol = fvcc::VectorCollection::instance(db, "VectorCollection");

--- a/test/test_distributedUnstructuredMesh.cpp
+++ b/test/test_distributedUnstructuredMesh.cpp
@@ -82,4 +82,35 @@ TEST_CASE("Distributed UnstructuredMesh")
         auto recvIdxExp = std::vector<int> {9, 10, 11, 12, 13, 14, 15, 16, 17};
         REQUIRE(commPattern.recvIdx == recvIdxExp);
     }
+
+    // OpenFOAM's `decomposePar -decompositionMethod cyclic` (the default for
+    // this 3-rank fixture) places original-mesh cell `i` on rank `i % nProc`.
+    // The cellProcAddressing files reflect this striping, so when the NeoFOAM
+    // mesh adapter reads them they must show up verbatim in
+    // `foamGlobalCellIds()`. This is the round-trip identity that
+    // reconstructPar and any other OF-side post-processing tool depends on.
+    //
+    // Note: these values are independent of `globalOffset()` / `commPattern`
+    // assertions above, which use the NeoN-internal contiguous numbering
+    // (MPI_Scan-based) consumed by Ginkgo. See commPattern audit REVIEW.md H3.
+    SECTION("foamGlobalCellIds reflects cellProcAddressing")
+    {
+        REQUIRE(rt.nfMesh.hasFoamAddressing());
+        REQUIRE(rt.nfMesh.foamGlobalCellIds().size() == 9);
+    }
+    SECTION_IF(rt.mpiEnvironment.rank() == 0, "Rank 0 owns OF cells {0, 3, 6, ..., 24}")
+    {
+        const auto expected = std::vector<NeoN::localIdx> {0, 3, 6, 9, 12, 15, 18, 21, 24};
+        REQUIRE(rt.nfMesh.foamGlobalCellIds() == expected);
+    }
+    SECTION_IF(rt.mpiEnvironment.rank() == 1, "Rank 1 owns OF cells {1, 4, 7, ..., 25}")
+    {
+        const auto expected = std::vector<NeoN::localIdx> {1, 4, 7, 10, 13, 16, 19, 22, 25};
+        REQUIRE(rt.nfMesh.foamGlobalCellIds() == expected);
+    }
+    SECTION_IF(rt.mpiEnvironment.rank() == 2, "Rank 2 owns OF cells {2, 5, 8, ..., 26}")
+    {
+        const auto expected = std::vector<NeoN::localIdx> {2, 5, 8, 11, 14, 17, 20, 23, 26};
+        REQUIRE(rt.nfMesh.foamGlobalCellIds() == expected);
+    }
 }

--- a/test/test_implicitOperators.cpp
+++ b/test/test_implicitOperators.cpp
@@ -20,7 +20,6 @@ extern Foam::fvMesh* meshPtr;  // A single mesh object
 
 TEST_CASE("matrix multiplication")
 {
-    NeoN::mpi::Environment mpiEnviron;
     float epsilon = 1e-32;
     Foam::Time& runTime = *timePtr;
     Foam::argList& args = *argsPtr;


### PR DESCRIPTION
## Summary

Teaches NeoFOAM's mesh adapter to read OpenFOAM's
`constant/polyMesh/cellProcAddressing` from disk on parallel runs and
plumb the per-cell global IDs into the new `UnstructuredMesh::foamGlobalCellIds`
field on the NeoN side.

Pairs with NeoN#<PR>. Both PRs target `enh/distributedGko`. Merging
requires the NeoN side to land first (or the submodule ref bumped at
the same time).

## Motivation — commPattern audit finding H3

NeoN currently invents its "global cell ID" via `MPI_Scan(localNCells)`,
which produces contiguous per-rank ranges. This matches OpenFOAM's
canonical `simple` decomposition but disagrees with Scotch and cyclic,
which permute cells arbitrarily across ranks. Without OF addressing on
the NeoN side, any future reconstruction or checkpoint round-trip would
silently corrupt cell identity. See REVIEW.md H3.

## What changes

```
src/datastructures/meshAdapter.cpp
test/test_distributedUnstructuredMesh.cpp
```

- New free function `readFoamGlobalCellIds(const Foam::fvMesh&)` that
  uses `READ_IF_PRESENT` on `cellProcAddressing` and returns the
  contents as `std::vector<NeoN::localIdx>` (empty when not on disk).
  Pure local-rank read; no MPI calls.
- `readOpenFOAMMesh` calls the reader and forwards the result to
  `NeoN::UnstructuredMesh`'s new constructor parameter.
- Behaviour on serial runs and synthetic test cases that never went
  through `decomposePar`: reader returns `{}`, mesh ends up with
  `foamGlobalCellIds().empty() == true` and `hasFoamAddressing() == false`.
- Behaviour on parallel runs decomposed via OF: each rank loads its own
  `processor<N>/constant/polyMesh/cellProcAddressing`. The resulting
  vector is the verbatim list of original-mesh cell IDs that this rank
  owns.

The NeoN-internal numbering exposed via `globalOffset()` is **not**
touched. `computeCommunicationPattern`, the off-diagonal sparsity row
indices, and Ginkgo's distributed matrix continue to use the
contiguous MPI_Scan numbering. See the dual-vector rationale in
the NeoN PR description.

## Test plan

- [x] `distributedUnstructuredMesh` (MPI_SIZE=3) extends the existing
      assertions with per-rank expectations on `foamGlobalCellIds`:

      | rank | expected `foamGlobalCellIds`             |
      |------|------------------------------------------|
      | 0    | `{0, 3, 6, 9, 12, 15, 18, 21, 24}`       |
      | 1    | `{1, 4, 7, 10, 13, 16, 19, 22, 25}`      |
      | 2    | `{2, 5, 8, 11, 14, 17, 20, 23, 26}`      |

      These match the contents of the existing
      `setup_pressureVelocityCoupling/processorN/constant/polyMesh/cellProcAddressing`
      files (cyclic-decomposed fixture).
- [x] Existing rank-by-rank `commPattern.sendCounts`/`recvIdx` /
      `globalOffset()` assertions remain unchanged — those probe the
      NeoN-internal numbering, not the new field.
- [x] Full NeoFOAM ctest suite (19/19) green locally when MPI tests
      run on CPU; verified `distributedMomentum` and
      `distributedPressureVelocityCoupling` were broken pre-existing
      flakes from this dev box's lack of CUDA-aware MPI, not regressions.
- [x] `distributedUnstructuredMesh` runs in ~3s and passes all 3 ranks.

## Out of scope (follow-ups)

- `faceProcAddressing` / `pointProcAddressing` readers (same pattern).
- Any consumer that uses `foamGlobalCellIds` for OF round-tripping
  (this PR makes the data available; consumers come next).
- Switching Ginkgo to a mapping-based partition so OF IDs can drive the
  distributed solve directly (would let the dual numbering collapse).

## Companion PR

NeoN#<PR> on `fix/global-addressing`. Required before this PR can be
merged (or the submodule must be bumped together).