### PR TITLE
Enh/dist logging

### DIFF
--- a/examples/neoIcoFoam/neoIcoFoam.cpp
+++ b/examples/neoIcoFoam/neoIcoFoam.cpp
@@ -40,8 +40,8 @@ int main(int argc, char* argv[])
 
 
         auto& solverDict = rt.fvSolutionDict.subDict("solvers");
-        solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"), "p");
-        solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"), "U");
+        solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"));
+        solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"));
         auto& schemesDict = rt.fvSchemesDict;
         schemesDict = nf::mapFvSchemes(rt.fvSchemesDict);
 

--- a/examples/neoIcoFoam/neoIcoFoam.cpp
+++ b/examples/neoIcoFoam/neoIcoFoam.cpp
@@ -40,8 +40,8 @@ int main(int argc, char* argv[])
 
 
         auto& solverDict = rt.fvSolutionDict.subDict("solvers");
-        solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"));
-        solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"));
+        solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"), "p");
+        solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"), "U");
         auto& schemesDict = rt.fvSchemesDict;
         schemesDict = nf::mapFvSchemes(rt.fvSchemesDict);
 

--- a/examples/neoPisoFoam/neoPisoFoam.cpp
+++ b/examples/neoPisoFoam/neoPisoFoam.cpp
@@ -30,14 +30,12 @@ namespace nf = NeoFOAM;
 
 int main(int argc, char* argv[])
 {
-// Initialize OpenFOAM (and thereby MPI) BEFORE NeoN so that NeoN::initialize
-// sees an initialized MPI environment and mutes logging on non-root ranks
-// (and maps Kokkos device ids by mpi_rank). Mirrors neoIcoFoam ordering.
+    NeoN::initialize(argc, argv);
+    {
 #include "addCheckCaseOptions.H"
 #include "setRootCase.H"
 #include "createTime.H"
-    NeoN::initialize(argc, argv);
-    {
+
         auto rt = nf::createAdapterRunTime(runTime);
         auto& mesh = rt.mesh;
 

--- a/examples/neoPisoFoam/neoPisoFoam.cpp
+++ b/examples/neoPisoFoam/neoPisoFoam.cpp
@@ -30,12 +30,13 @@ namespace nf = NeoFOAM;
 
 int main(int argc, char* argv[])
 {
-    NeoN::initialize(argc, argv);
-    {
+// Bring up OpenFOAM (and MPI) before NeoN, matching neoIcoFoam, so the rank is
+// known when NeoN configures logging and the rank-0 muting engages immediately.
 #include "addCheckCaseOptions.H"
 #include "setRootCase.H"
 #include "createTime.H"
-
+    NeoN::initialize(argc, argv);
+    {
         auto rt = nf::createAdapterRunTime(runTime);
         auto& mesh = rt.mesh;
 

--- a/examples/neoPisoFoam/neoPisoFoam.cpp
+++ b/examples/neoPisoFoam/neoPisoFoam.cpp
@@ -44,9 +44,9 @@ int main(int argc, char* argv[])
 #include "createFields.H"
 
         auto& solverDict = rt.fvSolutionDict.subDict("solvers");
-        solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"), "p");
-        solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"), "U");
-        solverDict.subDict("nuTilda") = nf::mapFvSolution(solverDict.subDict("nuTilda"), "nuTilda");
+        solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"));
+        solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"));
+        solverDict.subDict("nuTilda") = nf::mapFvSolution(solverDict.subDict("nuTilda"));
         auto& schemesDict = rt.fvSchemesDict;
         schemesDict = nf::mapFvSchemes(rt.fvSchemesDict);
 

--- a/examples/neoPisoFoam/neoPisoFoam.cpp
+++ b/examples/neoPisoFoam/neoPisoFoam.cpp
@@ -30,12 +30,14 @@ namespace nf = NeoFOAM;
 
 int main(int argc, char* argv[])
 {
-    NeoN::initialize(argc, argv);
-    {
+// Initialize OpenFOAM (and thereby MPI) BEFORE NeoN so that NeoN::initialize
+// sees an initialized MPI environment and mutes logging on non-root ranks
+// (and maps Kokkos device ids by mpi_rank). Mirrors neoIcoFoam ordering.
 #include "addCheckCaseOptions.H"
 #include "setRootCase.H"
 #include "createTime.H"
-
+    NeoN::initialize(argc, argv);
+    {
         auto rt = nf::createAdapterRunTime(runTime);
         auto& mesh = rt.mesh;
 
@@ -44,9 +46,9 @@ int main(int argc, char* argv[])
 #include "createFields.H"
 
         auto& solverDict = rt.fvSolutionDict.subDict("solvers");
-        solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"));
-        solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"));
-        solverDict.subDict("nuTilda") = nf::mapFvSolution(solverDict.subDict("nuTilda"));
+        solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"), "p");
+        solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"), "U");
+        solverDict.subDict("nuTilda") = nf::mapFvSolution(solverDict.subDict("nuTilda"), "nuTilda");
         auto& schemesDict = rt.fvSchemesDict;
         schemesDict = nf::mapFvSchemes(rt.fvSchemesDict);
 

--- a/include/NeoFOAM/compatibility/fvSolution.hpp
+++ b/include/NeoFOAM/compatibility/fvSolution.hpp
@@ -7,8 +7,6 @@
  */
 #pragma once
 
-#include <string>
-
 #include "NeoN/core/dictionary.hpp"
 
 
@@ -21,11 +19,12 @@ void updatePreconditioner(NeoN::Dictionary& solverDict);
 
 /* @brief Map an OpenFOAM fvSolution sub-dictionary to NeoN/Ginkgo settings.
  *
+ * The returned dictionary additionally carries a "reportName" meta key holding
+ * the Ginkgo solver/preconditioner label (e.g. "Ic+Cg") used by the per-solve
+ * residual report. The Ginkgo backend's config parser ignores that key.
+ *
  * @param solverDict  The OpenFOAM solver sub-dictionary (e.g. solvers/p).
- * @param fieldName   Optional field name, used only for an OpenFOAM-style
- *                    "preconditioner+solver" report logged once at setup
- *                    (e.g. "DICPCG"). No effect on the returned dictionary.
  */
-NeoN::Dictionary mapFvSolution(const NeoN::Dictionary& solverDict, const std::string& fieldName = "");
+NeoN::Dictionary mapFvSolution(const NeoN::Dictionary& solverDict);
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/compatibility/fvSolution.hpp
+++ b/include/NeoFOAM/compatibility/fvSolution.hpp
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include <string>
+
 #include "NeoN/core/dictionary.hpp"
 
 
@@ -17,6 +19,13 @@ void updateSolver(NeoN::Dictionary& solverDict);
 
 void updatePreconditioner(NeoN::Dictionary& solverDict);
 
-NeoN::Dictionary mapFvSolution(const NeoN::Dictionary& solverDict);
+/* @brief Map an OpenFOAM fvSolution sub-dictionary to NeoN/Ginkgo settings.
+ *
+ * @param solverDict  The OpenFOAM solver sub-dictionary (e.g. solvers/p).
+ * @param fieldName   Optional field name, used only for an OpenFOAM-style
+ *                    "preconditioner+solver" report logged once at setup
+ *                    (e.g. "DICPCG"). No effect on the returned dictionary.
+ */
+NeoN::Dictionary mapFvSolution(const NeoN::Dictionary& solverDict, const std::string& fieldName = "");
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/datastructures/pdeSolver.hpp
+++ b/include/NeoFOAM/datastructures/pdeSolver.hpp
@@ -153,16 +153,7 @@ public:
         // NF_ASSERT(ls.exec() == solution.exec(), "Executors are not the same");
         auto stats = solver.solve(ls, psi_.internalVector());
 
-        for (auto& stat : stats.entries)
-        {
-            NeoN::Logging::info(
-                "Solving for {} Initial residual: {} Final residual: {} No Iterations: {}",
-                psi_.name,
-                stat.initResNorm,
-                stat.finalResNorm,
-                stat.numIter
-            );
-        }
+        reportSolverStats(stats, fvSolution);
         return stats;
     }
 
@@ -205,21 +196,47 @@ public:
         auto solver = NeoN::la::Solver(psi_.exec(), fieldSolverDict);
         auto stats = solver.solve(ls, psi_.internalVector());
 
-        for (auto& stat : stats.entries)
-        {
-            NeoN::Logging::info(
-                "Solving for {} Initial residual: {} Final residual: {} No Iterations: {}",
-                psi_.name,
-                stat.initResNorm,
-                stat.finalResNorm,
-                stat.numIter
-            );
-        }
+        reportSolverStats(stats, fieldSolverDict);
 
         return stats;
     }
 
 private:
+
+    // Per-component name (Ux/Uy/Uz) when a vector field is solved as separate
+    // component systems; the plain field name otherwise (scalar or coupled solve).
+    static std::string componentName(const std::string& base, std::size_t i, std::size_t n)
+    {
+        if (n <= 1) return base;
+        constexpr const char* suffix[3] = {"x", "y", "z"};
+        return i < 3 ? base + suffix[i] : base + "[" + std::to_string(i) + "]";
+    }
+
+    // OpenFOAM-style per-solve residual report: "<precond><solver>:  Solving for
+    // <field>, Initial residual = ..., Final residual = ..., No Iterations N".
+    // The "<precond><solver>" label (e.g. DICPCG) is read from the solver dict's
+    // reportName meta key stashed by mapFvSolution -> no recomputation per solve.
+    // Logging is rank-aware and skips formatting on muted ranks (NeoN shouldLog).
+    void reportSolverStats(const NeoN::la::SolverStats& stats, const NeoN::Dictionary& fieldSolverDict)
+        const
+    {
+        const std::string label = fieldSolverDict.contains("reportName")
+                                    ? fieldSolverDict.get<std::string>("reportName")
+                                    : std::string("Ginkgo");
+        const std::size_t n = stats.entries.size();
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            const auto& stat = stats.entries[i];
+            NeoN::Logging::info(
+                "{}:  Solving for {}, Initial residual = {}, Final residual = {}, No Iterations {}",
+                label,
+                componentName(psi_.name, i, n),
+                stat.initResNorm,
+                stat.finalResNorm,
+                stat.numIter
+            );
+        }
+    }
 
     VolumeField& psi_;
     dsl::Expression<ValueType> expr_;

--- a/include/NeoFOAM/datastructures/pdeSolver.hpp
+++ b/include/NeoFOAM/datastructures/pdeSolver.hpp
@@ -217,8 +217,10 @@ private:
     // The "<precond><solver>" label (e.g. DICPCG) is read from the solver dict's
     // reportName meta key stashed by mapFvSolution -> no recomputation per solve.
     // Logging is rank-aware and skips formatting on muted ranks (NeoN shouldLog).
-    void reportSolverStats(const NeoN::la::SolverStats& stats, const NeoN::Dictionary& fieldSolverDict)
-        const
+    void reportSolverStats(
+        const NeoN::la::SolverStats& stats,
+        const NeoN::Dictionary& fieldSolverDict
+    ) const
     {
         const std::string label = fieldSolverDict.contains("reportName")
                                     ? fieldSolverDict.get<std::string>("reportName")

--- a/src/compatibility/fvSolution.cpp
+++ b/src/compatibility/fvSolution.cpp
@@ -204,9 +204,51 @@ void updateCriteria(NeoN::Dictionary& solverDict)
 }
 
 
-NeoN::Dictionary mapFvSolution(const NeoN::Dictionary& solverDict)
+namespace
+{
+
+// Build an OpenFOAM-style "preconditioner+solver" label (e.g. "DICPCG") from the
+// ORIGINAL OpenFOAM solver dictionary, before it is rewritten to Ginkgo names.
+std::string openFoamSolverLabel(const NeoN::Dictionary& solverDict)
+{
+    std::string solver =
+        solverDict.contains("solver") ? solverDict.get<std::string>("solver") : "unknown";
+
+    std::string precond;
+    // A dict-valued preconditioner is a user-provided Ginkgo config; leave it out
+    // of the short label. "none" and the smoother-only case have no preconditioner.
+    if (solverDict.contains("preconditioner") && !solverDict.isDict("preconditioner"))
+    {
+        const std::string& p = solverDict.get<std::string>("preconditioner");
+        if (p != "none") precond = p;
+    }
+    return precond + solver; // OpenFOAM prints the preconditioner first, e.g. DICPCG
+}
+
+// Report the selected solver+preconditioner once, at setup time (rank-aware
+// logger), so it never touches the per-solve hot path.
+void reportSolverSelection(const NeoN::Dictionary& solverDict, const std::string& fieldName)
+{
+    const std::string forField = fieldName.empty() ? "" : fmt::format(" for {}", fieldName);
+    if (solverDict.contains("configFile"))
+    {
+        NeoN::Logging::info(
+            "Selecting linear solver{}: Ginkgo config file {}",
+            forField,
+            solverDict.get<std::string>("configFile")
+        );
+        return;
+    }
+    NeoN::Logging::info("Selecting linear solver{}: {}", forField, openFoamSolverLabel(solverDict));
+}
+
+} // namespace
+
+NeoN::Dictionary mapFvSolution(const NeoN::Dictionary& solverDict, const std::string& fieldName)
 {
     NeoN::Dictionary modSolverDict = solverDict;
+
+    reportSolverSelection(solverDict, fieldName);
 
     if (solverDict.contains("configFile")) return solverDict;
     NeoN::Logging::warn("Mapping OpenFOAM solver settings to NeoN settings.\n"

--- a/src/compatibility/fvSolution.cpp
+++ b/src/compatibility/fvSolution.cpp
@@ -207,56 +207,78 @@ void updateCriteria(NeoN::Dictionary& solverDict)
 namespace
 {
 
-// Build an OpenFOAM-style "preconditioner+solver" label (e.g. "DICPCG") from the
-// ORIGINAL OpenFOAM solver dictionary, before it is rewritten to Ginkgo names.
-std::string openFoamSolverLabel(const NeoN::Dictionary& solverDict)
+// Strip a Ginkgo "namespace::Name" identifier down to "Name" (e.g.
+// "solver::Cg" -> "Cg", "preconditioner::Ic" -> "Ic").
+std::string stripNamespace(const std::string& s)
 {
-    std::string solver =
-        solverDict.contains("solver") ? solverDict.get<std::string>("solver") : "unknown";
-
-    std::string precond;
-    // A dict-valued preconditioner is a user-provided Ginkgo config; leave it out
-    // of the short label. "none" and the smoother-only case have no preconditioner.
-    if (solverDict.contains("preconditioner") && !solverDict.isDict("preconditioner"))
-    {
-        const std::string& p = solverDict.get<std::string>("preconditioner");
-        if (p != "none") precond = p;
-    }
-    return precond + solver; // OpenFOAM prints the preconditioner first, e.g. DICPCG
+    const auto pos = s.rfind("::");
+    return pos == std::string::npos ? s : s.substr(pos + 2);
 }
 
-// Report the selected solver+preconditioner once, at setup time (rank-aware
-// logger), so it never touches the per-solve hot path.
-void reportSolverSelection(const NeoN::Dictionary& solverDict, const std::string& fieldName)
+// Build a label from the Ginkgo solver/preconditioner ACTUALLY selected after
+// mapping (e.g. "Ic+Cg", or "Schwarz(Ic)+Cg" for a distributed run). Reads the
+// post-mapping dictionary, so it reflects exactly what NeoN/Ginkgo will run.
+std::string ginkgoSolverLabel(const NeoN::Dictionary& mapped)
 {
-    const std::string forField = fieldName.empty() ? "" : fmt::format(" for {}", fieldName);
-    if (solverDict.contains("configFile"))
+    if (mapped.contains("configFile")) return "configFile";
+
+    std::string solver =
+        mapped.contains("type") ? stripNamespace(mapped.get<std::string>("type")) : "Ginkgo";
+
+    std::string precond;
+    if (mapped.contains("preconditioner"))
     {
-        NeoN::Logging::info(
-            "Selecting linear solver{}: Ginkgo config file {}",
-            forField,
-            solverDict.get<std::string>("configFile")
-        );
-        return;
+        if (mapped.isDict("preconditioner"))
+        {
+            const NeoN::Dictionary& pd = mapped.subDict("preconditioner");
+            if (pd.contains("type"))
+            {
+                const std::string ptype = pd.get<std::string>("type");
+                precond = stripNamespace(ptype);
+                // Unwrap the additive-Schwarz local solver so the meaningful
+                // per-rank preconditioner is visible in distributed runs.
+                if (ptype == "preconditioner::Schwarz" && pd.contains("local_solver")
+                    && pd.isDict("local_solver"))
+                {
+                    const NeoN::Dictionary& ld = pd.subDict("local_solver");
+                    if (ld.contains("type"))
+                        precond += "(" + stripNamespace(ld.get<std::string>("type")) + ")";
+                }
+            }
+        }
+        else
+        {
+            precond = stripNamespace(mapped.get<std::string>("preconditioner"));
+        }
     }
-    NeoN::Logging::info("Selecting linear solver{}: {}", forField, openFoamSolverLabel(solverDict));
+    return precond.empty() ? solver : precond + "+" + solver;
 }
 
 } // namespace
 
 NeoN::Dictionary mapFvSolution(const NeoN::Dictionary& solverDict, const std::string& fieldName)
 {
+    (void)fieldName; // residual reporting uses the field name carried by the solver
     NeoN::Dictionary modSolverDict = solverDict;
 
-    reportSolverSelection(solverDict, fieldName);
+    if (solverDict.contains("configFile"))
+    {
+        modSolverDict.insert("reportName", std::string("configFile"));
+        return modSolverDict;
+    }
 
-    if (solverDict.contains("configFile")) return solverDict;
     NeoN::Logging::warn("Mapping OpenFOAM solver settings to NeoN settings.\n"
                         "Currently, it is advisable to specify a configFile\n"
                         "for fine grained Ginkgo solver control\n");
     updateSolver(modSolverDict);
     updatePreconditioner(modSolverDict);
     updateCriteria(modSolverDict);
+
+    // Stash the Ginkgo solver/preconditioner label (e.g. "Ic+Cg") that fvSolution
+    // mapped to, for the per-solve residual report. Read from the post-mapping
+    // dict so it reflects what Ginkgo runs; the Ginkgo backend's parse() ignores
+    // this meta key. Computed once here -> no per-solve / hot-path cost.
+    modSolverDict.insert("reportName", ginkgoSolverLabel(modSolverDict));
 
     return modSolverDict;
 }

--- a/src/compatibility/fvSolution.cpp
+++ b/src/compatibility/fvSolution.cpp
@@ -256,9 +256,8 @@ std::string ginkgoSolverLabel(const NeoN::Dictionary& mapped)
 
 } // namespace
 
-NeoN::Dictionary mapFvSolution(const NeoN::Dictionary& solverDict, const std::string& fieldName)
+NeoN::Dictionary mapFvSolution(const NeoN::Dictionary& solverDict)
 {
-    (void)fieldName; // residual reporting uses the field name carried by the solver
     NeoN::Dictionary modSolverDict = solverDict;
 
     if (solverDict.contains("configFile"))

--- a/test/test_compatibility.cpp
+++ b/test/test_compatibility.cpp
@@ -86,4 +86,38 @@ TEST_CASE("fvSolution")
             );
         }
     }
+
+    // The mapped dictionary carries a "reportName" label (Ginkgo
+    // preconditioner+solver) that the per-solve residual report prints. These
+    // run serially, so the serial (non-Schwarz) preconditioner names apply.
+    SECTION("mapFvSolution reportName")
+    {
+        SECTION("DIC + PCG -> Ic+Cg")
+        {
+            solver1.insert("solver", std::string("PCG"));
+            solver1.insert("preconditioner", std::string("DIC"));
+            auto mapped = NeoFOAM::mapFvSolution(solver1);
+            REQUIRE(mapped.get<std::string>("reportName") == "Ic+Cg");
+        }
+        SECTION("DILU + PBiCGStab -> Ilu+Bicgstab")
+        {
+            solver1.insert("solver", std::string("PBiCGStab"));
+            solver1.insert("preconditioner", std::string("DILU"));
+            auto mapped = NeoFOAM::mapFvSolution(solver1);
+            REQUIRE(mapped.get<std::string>("reportName") == "Ilu+Bicgstab");
+        }
+        SECTION("diagonal + PCG -> Jacobi+Cg")
+        {
+            solver1.insert("solver", std::string("PCG"));
+            solver1.insert("preconditioner", std::string("diagonal"));
+            auto mapped = NeoFOAM::mapFvSolution(solver1);
+            REQUIRE(mapped.get<std::string>("reportName") == "Jacobi+Cg");
+        }
+        SECTION("configFile -> configFile")
+        {
+            solver1.insert("configFile", std::string("mySolver.json"));
+            auto mapped = NeoFOAM::mapFvSolution(solver1);
+            REQUIRE(mapped.get<std::string>("reportName") == "configFile");
+        }
+    }
 }


### PR DESCRIPTION
Improved logging off the solvers:
- The residual lines are now prefixed with the Ginkgo preconditioner and solver. 
- Component labels in the log for vector variables.
- Also only rank 0 writes to log in the distributed case. 