### PR TITLE
enh: segregated scalar-matrix momentum solve

### DIFF
--- a/benchmarks/momentum.cpp
+++ b/benchmarks/momentum.cpp
@@ -99,9 +99,8 @@ TEST_CASE("momentum")
                     rt
                 );
                 auto expr = dsl::Expression<NeoN::Vec3>(eqn.expression());
-                auto ls = NeoN::la::LinearSystem<
-                    NeoN::Vec3,
-                    NeoN::la::CSRMatrix<NeoN::Vec3, NeoN::localIdx>>(eqn.linearSystem());
+                // momentum assembles into a scalar matrix with Vec3 rhs (segregated solve)
+                auto ls = NeoN::la::LinearSystem<NeoN::scalar, NeoN::Vec3>(eqn.linearSystem());
                 expr.addOperator(-1.0 * dsl::exp::grad(nfP));
                 eqn.assemble();
                 expr.assemble(rt.t, rt.dt, ls);

--- a/benchmarks/momentum.cpp
+++ b/benchmarks/momentum.cpp
@@ -99,8 +99,7 @@ TEST_CASE("momentum")
                     rt
                 );
                 auto expr = dsl::Expression<NeoN::Vec3>(eqn.expression());
-                // momentum assembles into a scalar matrix with Vec3 rhs (segregated solve)
-                auto ls = NeoN::la::LinearSystem<NeoN::scalar, NeoN::Vec3>(eqn.linearSystem());
+                auto ls = eqn.linearSystem();
                 expr.addOperator(-1.0 * dsl::exp::grad(nfP));
                 eqn.assemble();
                 expr.assemble(rt.t, rt.dt, ls);

--- a/include/NeoFOAM/datastructures/pdeSolver.hpp
+++ b/include/NeoFOAM/datastructures/pdeSolver.hpp
@@ -20,11 +20,18 @@ namespace NeoFOAM
  * for dependent operations like discrete momentum fields
  * needs storage for assembled matrix? and whether update is needed like for rAU and HbyA
  */
-template<typename ValueType, typename IndexType = NeoN::localIdx>
+template<
+    typename ValueType,
+    typename MatrixValueType = NeoN::scalar,
+    typename IndexType = NeoN::localIdx>
 class PDESolver
 {
     using VolumeField = NeoN::finiteVolume::cellCentred::VolumeField<ValueType>;
-    using LinearSystem = NeoN::la::LinearSystem<ValueType>;
+    // Matrix coefficients use MatrixValueType (scalar by default, giving the segregated
+    // vector-solve form for Vec3 fields); the rhs/solution use the field's ValueType.
+    // TODO: future work selects MatrixValueType == ValueType (the coupled Vec3 matrix)
+    // based on the presence of boundary conditions that require the full block-coupled form.
+    using LinearSystem = NeoN::la::LinearSystem<MatrixValueType, ValueType>;
 
 public:
 
@@ -37,7 +44,7 @@ public:
               "linearSystem" + psi.name,
               // FIXME find a proper place
               [&psi, &runTime]()
-              { return NeoN::la::createEmptyLinearSystem<ValueType>(psi.mesh()); }
+              { return NeoN::la::createEmptyLinearSystem<MatrixValueType, ValueType>(psi.mesh()); }
           ))
     {
         expr_.read(runTime_.fvSchemesDict);
@@ -107,12 +114,11 @@ public:
      * 2. a copy of the assembled linear system is made and the rhs is assembled
      * 3. the new linear system with rhs is returned
      */
-    NeoN::la::LinearSystem<ValueType> assemble(dsl::SpatialOperator<NeoN::Vec3>&& rhs)
+    LinearSystem assemble(dsl::SpatialOperator<NeoN::Vec3>&& rhs)
     {
         auto rhsExpr = dsl::Expression<ValueType>(-1.0 * rhs);
         rhsExpr.read(runTime_.fvSchemesDict);
-        auto ls =
-            NeoN::la::LinearSystem<ValueType>(assemble()); // includes expr_'s explicit sources
+        auto ls = LinearSystem(assemble());
         rhsExpr.assembleExplicitSource(ls, psi_.mesh());
 
         return ls;
@@ -249,9 +255,9 @@ NeoN::finiteVolume::cellCentred::VolumeField<ValueType> applyOperator(
 }
 
 
-template<typename ValueType, typename IndexType = NeoN::localIdx>
+template<typename ValueType>
 NeoN::finiteVolume::cellCentred::VolumeField<ValueType> operator&(
-    const PDESolver<ValueType, IndexType> expr,
+    const PDESolver<ValueType>& expr,
     const NeoN::finiteVolume::cellCentred::VolumeField<ValueType>& psi
 )
 {

--- a/src/algorithms/pressureVelocityCoupling.cpp
+++ b/src/algorithms/pressureVelocityCoupling.cpp
@@ -98,12 +98,15 @@ computeRAUandHByA(const PDESolver<Vec3>& expr)
             {0, nProcFaces},
             NEON_LAMBDA(const NeoN::localIdx procFacei) {
                 auto own = static_cast<std::size_t>(bfOwners[nBoundaryFaces + procFacei]);
+                // scalar off-diagonal coupling (segregated vector-solve form): the single
+                // coefficient applies to every velocity component. The future coupled Vec3
+                // matrix path would index coeff per component (coeff[0..2]).
                 auto coeff = nlValues[procFacei];
                 auto uG = uGhostV[nBoundaryFaces + procFacei];
                 auto scale = rAUV[own] / volV[own];
-                Kokkos::atomic_sub(&hByAV[own][0], coeff[0] * uG[0] * scale);
-                Kokkos::atomic_sub(&hByAV[own][1], coeff[1] * uG[1] * scale);
-                Kokkos::atomic_sub(&hByAV[own][2], coeff[2] * uG[2] * scale);
+                Kokkos::atomic_sub(&hByAV[own][0], coeff * uG[0] * scale);
+                Kokkos::atomic_sub(&hByAV[own][1], coeff * uG[1] * scale);
+                Kokkos::atomic_sub(&hByAV[own][2], coeff * uG[2] * scale);
             },
             "computeHbyAProcBoundary"
         );

--- a/test/test_distributedPressureVelocityCoupling.cpp
+++ b/test/test_distributedPressureVelocityCoupling.cpp
@@ -213,9 +213,11 @@ TEST_CASE("Distributed PressureVelocityCoupling")
         //     EqualsInternal(ofUEqn.diag(), ApproxVector(1e-15))
         // );
 
+        // momentum is assembled into a scalar matrix (segregated form); OpenFOAM's
+        // fvVectorMatrix upper() is likewise scalar.
         REQUIRE_THAT(
             NeoN::la::upper(nfUEqn.linearSystem().matrix()),
-            EqualsInternal(ofUEqn.upper(), ApproxVector(1e-15))
+            EqualsInternal(ofUEqn.upper(), ApproxScalar {1e-15})
         );
 
         auto [nfrAU, nfHbyA] = nf::computeRAUandHByA(nfUEqn);

--- a/test/test_pressureVelocityCoupling.cpp
+++ b/test/test_pressureVelocityCoupling.cpp
@@ -98,9 +98,11 @@ TEST_CASE("PressureVelocityCoupling")
         Foam::volScalarField forAU("rAU", 1.0 / ofUEqn.A());
         nfUEqn.assemble();
 
+        // The momentum system is assembled into a scalar matrix (segregated vector-solve form),
+        // matching OpenFOAM's fvVectorMatrix whose upper()/diag() coefficients are scalar.
         REQUIRE_THAT(
             NeoN::la::upper(nfUEqn.linearSystem().matrix()),
-            EqualsInternal(ofUEqn.upper(), ApproxVector(1e-15))
+            EqualsInternal(ofUEqn.upper(), ApproxScalar {1e-15})
         );
 
         // NeoN stores boundary diagonal contributions directly in the matrix, whereas
@@ -108,7 +110,7 @@ TEST_CASE("PressureVelocityCoupling")
         // coefficients.
         REQUIRE_THAT(
             NeoN::la::removeBoundaryContributions(nfUEqn.linearSystem()).matrix().diag(),
-            EqualsInternal(ofUEqn.diag(), ApproxVector(1e-15))
+            EqualsInternal(ofUEqn.diag(), ApproxScalar {1e-15})
         );
 
         auto nfrAU = nf::computeRAU(nfUEqn);


### PR DESCRIPTION
PDESolver gains a defaulted MatrixValueType = scalar template param, so PDESolver<Vec3> assembles into LinearSystem<scalar, Vec3> (scalar matrix, Vec3 rhs), matching OpenFOAM's segregated fvVectorMatrix. The coupled Vec3 matrix stays reachable as PDESolver<Vec3, Vec3> for a future BC-driven runtime selection.

- pressureVelocityCoupling: scalar off-diagonal coupling in computeRAUandHByA
- tests: compare momentum upper()/diag() with ApproxScalar (now scalar)
- benchmark: assemble momentum into LinearSystem<scalar, Vec3>