### PR TITLE
Quick/scope sa ddes intermediates

### DIFF
--- a/include/NeoFOAM/turbulenceModels/spalartAllmarasDDES.hpp
+++ b/include/NeoFOAM/turbulenceModels/spalartAllmarasDDES.hpp
@@ -170,14 +170,20 @@ private:
     // Cached face-interpolated nu (computed once in constructor)
     nnfvcc::SurfaceField<scalar> surfNu_;
 
-    // Persistent intermediate fields that must outlive a single turbulence update:
-    //  - gradU_ : consumed by the next step's momentum predictor (viscousStress) and devRhoReff
-    //  - nuEff_ : consumed by the next step's momentum laplacian coefficient
-    // All other SA-DDES intermediates (gradNuTilda, magSqrGradNuTilda, production, spCoeff,
-    // surfNut, surfNuTilda, nuTildaEff) are now function-local to validate()/correct() so they
-    // do not occupy device memory during the pressure-solve peak (the run's high-water mark).
+    // Persistent intermediate fields that must outlive a single turbulence update. Each carries
+    // state across calls: it is computed at the END of one validate()/correct() and consumed at
+    // the START of the next, so it cannot be a function-local.
+    //  - gradU_      : next step's momentum predictor (viscousStress) and devRhoReff
+    //  - nuEff_      : next step's momentum laplacian coefficient
+    //  - nuTildaEff_ : the nuTilda laplacian coefficient consumed by the nuTilda solve at the
+    //                  start of the NEXT correct() (lagged exactly as OpenFOAM computes DnuTildaEff
+    //                  from the incoming nuTilda — nuTilda is unchanged between calls)
+    // The remaining SA-DDES intermediates (gradNuTilda, magSqrGradNuTilda, production, spCoeff,
+    // surfNut, surfNuTilda) are function-local to validate()/correct() so they do not occupy
+    // device memory during the pressure-solve peak (the run's high-water mark).
     nnfvcc::VolumeField<NeoN::Tensor> gradU_;
     nnfvcc::SurfaceField<scalar> nuEff_;
+    nnfvcc::SurfaceField<scalar> nuTildaEff_;
 
     // Cached operators (constructed once)
     nnfvcc::GaussGreenGrad gradOp_;

--- a/include/NeoFOAM/turbulenceModels/spalartAllmarasDDES.hpp
+++ b/include/NeoFOAM/turbulenceModels/spalartAllmarasDDES.hpp
@@ -105,9 +105,6 @@ public:
     /// @brief Effective viscosity on faces: nu + nut (for momentum equation laplacian)
     nnfvcc::SurfaceField<scalar>& nuEff();
 
-    /// @brief Effective nuTilda diffusion coefficient on faces: (nu + nuTilda)/sigmaNut
-    nnfvcc::SurfaceField<scalar>& nuTildaEff();
-
     /// @brief Velocity gradient tensor (updated each correct() call, for viscousStress term)
     const nnfvcc::VolumeField<NeoN::Tensor>& gradU() const;
 
@@ -173,16 +170,14 @@ private:
     // Cached face-interpolated nu (computed once in constructor)
     nnfvcc::SurfaceField<scalar> surfNu_;
 
-    // Owned intermediate fields
+    // Persistent intermediate fields that must outlive a single turbulence update:
+    //  - gradU_ : consumed by the next step's momentum predictor (viscousStress) and devRhoReff
+    //  - nuEff_ : consumed by the next step's momentum laplacian coefficient
+    // All other SA-DDES intermediates (gradNuTilda, magSqrGradNuTilda, production, spCoeff,
+    // surfNut, surfNuTilda, nuTildaEff) are now function-local to validate()/correct() so they
+    // do not occupy device memory during the pressure-solve peak (the run's high-water mark).
     nnfvcc::VolumeField<NeoN::Tensor> gradU_;
-    nnfvcc::VolumeField<Vec3> gradNuTilda_;
-    nnfvcc::VolumeField<scalar> magSqrGradNuTilda_;
-    nnfvcc::VolumeField<scalar> production_;
-    nnfvcc::VolumeField<scalar> spCoeff_;
-    nnfvcc::SurfaceField<scalar> surfNut_;
-    nnfvcc::SurfaceField<scalar> surfNuTilda_;
     nnfvcc::SurfaceField<scalar> nuEff_;
-    nnfvcc::SurfaceField<scalar> nuTildaEff_;
 
     // Cached operators (constructed once)
     nnfvcc::GaussGreenGrad gradOp_;

--- a/src/turbulenceModels/spalartAllmarasDDES.cpp
+++ b/src/turbulenceModels/spalartAllmarasDDES.cpp
@@ -254,49 +254,7 @@ SpalartAllmarasDDES::SpalartAllmarasDDES(
           // in divDevReff interpolates the correct far-side gradient across the rank boundary.
           fvcc::createCalculatedProcBCs<nnfvcc::VolumeBoundary<Tensor>>(mesh)
       )
-    , gradNuTilda_(
-          exec,
-          "gradNuTilda",
-          mesh,
-          fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<Vec3>>(mesh)
-      )
-    , magSqrGradNuTilda_(
-          exec,
-          "magSqrGradNuTilda",
-          mesh,
-          fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh)
-      )
-    , production_(
-          exec,
-          "production",
-          mesh,
-          fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh)
-      )
-    , spCoeff_(
-          exec,
-          "spCoeff",
-          mesh,
-          fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh)
-      )
-    , surfNut_(
-          exec,
-          "surfNut",
-          mesh,
-          fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh)
-      )
-    , surfNuTilda_(
-          exec,
-          "surfNuTilda",
-          mesh,
-          fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh)
-      )
     , nuEff_(exec, "nuEff", mesh, fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh))
-    , nuTildaEff_(
-          exec,
-          "DnuTildaEff",
-          mesh,
-          fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh)
-      )
     , gradOp_(exec, mesh)
     , surfInterp_(exec, mesh, NeoN::TokenList({std::string("linear")}))
     , coeffs_()
@@ -319,8 +277,23 @@ void SpalartAllmarasDDES::validate(
     // Exchange the neighbour-cell gradient into gradU's processor tail (proc patches carry the
     // processor BC; physical patches are 'calculated' no-ops, so their boundary gradient is kept).
     gradU_.correctBoundaryConditions();
-    calcNuTildaDiffusionCoeff(nuTilda, surfNu_, surfNuTilda_, nuTildaEff_);
-    correctNut(nut, surfNut_, nuEff_, nuTilda, nu_, surfNu_, U, nearWallDist_);
+
+    // Function-local intermediates (see header note): live only for this update so they do not
+    // occupy device memory between calls / during the pressure-solve peak.
+    nnfvcc::SurfaceField<scalar> surfNut(
+        exec_, "surfNut", mesh_, fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
+    );
+    nnfvcc::SurfaceField<scalar> surfNuTilda(
+        exec_, "surfNuTilda", mesh_,
+        fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
+    );
+    nnfvcc::SurfaceField<scalar> nuTildaEff(
+        exec_, "DnuTildaEff", mesh_,
+        fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
+    );
+
+    calcNuTildaDiffusionCoeff(nuTilda, surfNu_, surfNuTilda, nuTildaEff);
+    correctNut(nut, surfNut, nuEff_, nuTilda, nu_, surfNu_, U, nearWallDist_);
 }
 
 void SpalartAllmarasDDES::correct(
@@ -334,24 +307,53 @@ void SpalartAllmarasDDES::correct(
     gradOp_.gradTensor(U, gradU_);
     // Exchange the neighbour-cell gradient into gradU's processor tail (see validate()).
     gradU_.correctBoundaryConditions();
-    gradOp_.grad(nuTilda, gradNuTilda_);
-    calcMagSqrVec(magSqrGradNuTilda_, gradNuTilda_);
+
+    // Function-local intermediates (see header note): allocated only for this turbulence update
+    // so they are not resident during the pressure-solve peak (the run's high-water mark).
+    // gradNuTilda is a pure throwaway used solely to form the scalar magSqrGradNuTilda.
+    nnfvcc::VolumeField<Vec3> gradNuTilda(
+        exec_, "gradNuTilda", mesh_, fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<Vec3>>(mesh_)
+    );
+    nnfvcc::VolumeField<scalar> magSqrGradNuTilda(
+        exec_, "magSqrGradNuTilda", mesh_,
+        fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh_)
+    );
+    nnfvcc::VolumeField<scalar> production(
+        exec_, "production", mesh_, fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh_)
+    );
+    nnfvcc::VolumeField<scalar> spCoeff(
+        exec_, "spCoeff", mesh_, fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh_)
+    );
+    nnfvcc::SurfaceField<scalar> surfNut(
+        exec_, "surfNut", mesh_, fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
+    );
+    nnfvcc::SurfaceField<scalar> surfNuTilda(
+        exec_, "surfNuTilda", mesh_,
+        fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
+    );
+    nnfvcc::SurfaceField<scalar> nuTildaEff(
+        exec_, "DnuTildaEff", mesh_,
+        fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
+    );
+
+    gradOp_.grad(nuTilda, gradNuTilda);
+    calcMagSqrVec(magSqrGradNuTilda, gradNuTilda);
 
     computeProdSpDDES(
-        production_,
-        spCoeff_,
+        production,
+        spCoeff,
         nuTilda,
         nu_,
         gradU_,
         wallDist_,
         delta_,
-        magSqrGradNuTilda_
+        magSqrGradNuTilda
     );
 
     PDESolver<scalar> nuTildaEqn(
         dsl::imp::ddt(nuTilda) + dsl::imp::div(phi, nuTilda)
-            - dsl::imp::laplacian(nuTildaEff_, nuTilda) + dsl::imp::source(spCoeff_, nuTilda)
-            - dsl::exp::source(production_),
+            - dsl::imp::laplacian(nuTildaEff, nuTilda) + dsl::imp::source(spCoeff, nuTilda)
+            - dsl::exp::source(production),
         nuTilda,
         rt
     );
@@ -369,13 +371,11 @@ void SpalartAllmarasDDES::correct(
         nuTilda.correctBoundaryConditions();
     }
 
-    calcNuTildaDiffusionCoeff(nuTilda, surfNu_, surfNuTilda_, nuTildaEff_);
-    correctNut(nut, surfNut_, nuEff_, nuTilda, nu_, surfNu_, U, nearWallDist_);
+    calcNuTildaDiffusionCoeff(nuTilda, surfNu_, surfNuTilda, nuTildaEff);
+    correctNut(nut, surfNut, nuEff_, nuTilda, nu_, surfNu_, U, nearWallDist_);
 }
 
 nnfvcc::SurfaceField<scalar>& SpalartAllmarasDDES::nuEff() { return nuEff_; }
-
-nnfvcc::SurfaceField<scalar>& SpalartAllmarasDDES::nuTildaEff() { return nuTildaEff_; }
 
 const nnfvcc::VolumeField<Tensor>& SpalartAllmarasDDES::gradU() const { return gradU_; }
 

--- a/src/turbulenceModels/spalartAllmarasDDES.cpp
+++ b/src/turbulenceModels/spalartAllmarasDDES.cpp
@@ -255,6 +255,12 @@ SpalartAllmarasDDES::SpalartAllmarasDDES(
           fvcc::createCalculatedProcBCs<nnfvcc::VolumeBoundary<Tensor>>(mesh)
       )
     , nuEff_(exec, "nuEff", mesh, fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh))
+    , nuTildaEff_(
+          exec,
+          "DnuTildaEff",
+          mesh,
+          fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh)
+      )
     , gradOp_(exec, mesh)
     , surfInterp_(exec, mesh, NeoN::TokenList({std::string("linear")}))
     , coeffs_()
@@ -281,18 +287,21 @@ void SpalartAllmarasDDES::validate(
     // Function-local intermediates (see header note): live only for this update so they do not
     // occupy device memory between calls / during the pressure-solve peak.
     nnfvcc::SurfaceField<scalar> surfNut(
-        exec_, "surfNut", mesh_, fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
-    );
-    nnfvcc::SurfaceField<scalar> surfNuTilda(
-        exec_, "surfNuTilda", mesh_,
+        exec_,
+        "surfNut",
+        mesh_,
         fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
     );
-    nnfvcc::SurfaceField<scalar> nuTildaEff(
-        exec_, "DnuTildaEff", mesh_,
+    nnfvcc::SurfaceField<scalar> surfNuTilda(
+        exec_,
+        "surfNuTilda",
+        mesh_,
         fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
     );
 
-    calcNuTildaDiffusionCoeff(nuTilda, surfNu_, surfNuTilda, nuTildaEff);
+    // nuTildaEff_ is a persistent member (see header): writing it here seeds the coefficient that
+    // the first correct()'s nuTilda solve will read.
+    calcNuTildaDiffusionCoeff(nuTilda, surfNu_, surfNuTilda, nuTildaEff_);
     correctNut(nut, surfNut, nuEff_, nuTilda, nu_, surfNu_, U, nearWallDist_);
 }
 
@@ -312,30 +321,41 @@ void SpalartAllmarasDDES::correct(
     // so they are not resident during the pressure-solve peak (the run's high-water mark).
     // gradNuTilda is a pure throwaway used solely to form the scalar magSqrGradNuTilda.
     nnfvcc::VolumeField<Vec3> gradNuTilda(
-        exec_, "gradNuTilda", mesh_, fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<Vec3>>(mesh_)
+        exec_,
+        "gradNuTilda",
+        mesh_,
+        fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<Vec3>>(mesh_)
     );
     nnfvcc::VolumeField<scalar> magSqrGradNuTilda(
-        exec_, "magSqrGradNuTilda", mesh_,
+        exec_,
+        "magSqrGradNuTilda",
+        mesh_,
         fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh_)
     );
     nnfvcc::VolumeField<scalar> production(
-        exec_, "production", mesh_, fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh_)
+        exec_,
+        "production",
+        mesh_,
+        fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh_)
     );
     nnfvcc::VolumeField<scalar> spCoeff(
-        exec_, "spCoeff", mesh_, fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh_)
+        exec_,
+        "spCoeff",
+        mesh_,
+        fvcc::createCalculatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh_)
     );
     nnfvcc::SurfaceField<scalar> surfNut(
-        exec_, "surfNut", mesh_, fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
+        exec_,
+        "surfNut",
+        mesh_,
+        fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
     );
     nnfvcc::SurfaceField<scalar> surfNuTilda(
-        exec_, "surfNuTilda", mesh_,
+        exec_,
+        "surfNuTilda",
+        mesh_,
         fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
     );
-    nnfvcc::SurfaceField<scalar> nuTildaEff(
-        exec_, "DnuTildaEff", mesh_,
-        fvcc::createCalculatedBCs<nnfvcc::SurfaceBoundary<scalar>>(mesh_)
-    );
-
     gradOp_.grad(nuTilda, gradNuTilda);
     calcMagSqrVec(magSqrGradNuTilda, gradNuTilda);
 
@@ -352,7 +372,7 @@ void SpalartAllmarasDDES::correct(
 
     PDESolver<scalar> nuTildaEqn(
         dsl::imp::ddt(nuTilda) + dsl::imp::div(phi, nuTilda)
-            - dsl::imp::laplacian(nuTildaEff, nuTilda) + dsl::imp::source(spCoeff, nuTilda)
+            - dsl::imp::laplacian(nuTildaEff_, nuTilda) + dsl::imp::source(spCoeff, nuTilda)
             - dsl::exp::source(production),
         nuTilda,
         rt
@@ -371,7 +391,7 @@ void SpalartAllmarasDDES::correct(
         nuTilda.correctBoundaryConditions();
     }
 
-    calcNuTildaDiffusionCoeff(nuTilda, surfNu_, surfNuTilda, nuTildaEff);
+    calcNuTildaDiffusionCoeff(nuTilda, surfNu_, surfNuTilda, nuTildaEff_);
     correctNut(nut, surfNut, nuEff_, nuTilda, nu_, surfNu_, U, nearWallDist_);
 }
 


### PR DESCRIPTION
Reduce memory high water mark by scoping internal turbulence variables to be only local.