### PR TITLE
feat(grad): wire up cellLimited gradient scheme via NeoN

### DIFF
--- a/src/compatibility/fvSchemes.cpp
+++ b/src/compatibility/fvSchemes.cpp
@@ -57,6 +57,10 @@ NeoN::Dictionary mapFvSchemes(const NeoN::Dictionary& schemesDict)
     updateDdtSchemes(modSchemesDict);
     // snGrad scheme names (corrected, uncorrected, limited [corrected] <coeff>)
     // are accepted by NeoN's factories directly — no remapping required.
+    // gradSchemes likewise need no remapping: OpenFOAM's "Gauss <interp>" and
+    // "cellLimited Gauss <interp> <coeff>" token lists are consumed verbatim by
+    // NeoN's GradOperatorFactory (the cellLimited factory wraps the base scheme
+    // and reads the trailing limiter coefficient).
 
     return modSchemesDict;
 }


### PR DESCRIPTION
Bump the src/NeoN submodule to the cellLimited gradient implementation and note in mapFvSchemes that OpenFOAM's gradSchemes token lists (Gauss <interp>, cellLimited Gauss <interp> <coeff>) are consumed verbatim by NeoN's GradOperatorFactory with no remapping required.