### PR TITLE
fix(pdeSolver): apply deferred non-orth flux correction in updateFaceVelocity

### DIFF
--- a/examples/neoIcoFoam/neoIcoFoam.cpp
+++ b/examples/neoIcoFoam/neoIcoFoam.cpp
@@ -138,6 +138,7 @@ int main(int argc, char* argv[])
 
                     // updateFaceVelocity reconstructs phi from this pressure system; keep the
                     // non-orthogonal faceFluxCorrection so the reconstruction can add it back.
+                    // TODO find a more suitable spot
                     pEqn.linearSystem().keepFaceFluxCorrection(true);
 
                     if (ofP.needReference() && pRefCell >= 0)

--- a/examples/neoIcoFoam/neoIcoFoam.cpp
+++ b/examples/neoIcoFoam/neoIcoFoam.cpp
@@ -136,6 +136,10 @@ int main(int argc, char* argv[])
                         rt
                     );
 
+                    // updateFaceVelocity reconstructs phi from this pressure system; keep the
+                    // non-orthogonal faceFluxCorrection so the reconstruction can add it back.
+                    pEqn.linearSystem().keepFaceFluxCorrection(true);
+
                     if (ofP.needReference() && pRefCell >= 0)
                     {
                         pEqn.setReference(pRefCell, pRefValue);

--- a/examples/neoPisoFoam/neoPisoFoam.cpp
+++ b/examples/neoPisoFoam/neoPisoFoam.cpp
@@ -155,6 +155,7 @@ int main(int argc, char* argv[])
 
                     // updateFaceVelocity reconstructs phi from this pressure system; keep the
                     // non-orthogonal faceFluxCorrection so the reconstruction can add it back.
+                    // TODO find a more suitable spot
                     pEqn.linearSystem().keepFaceFluxCorrection(true);
 
                     if (ofP.needReference() && pRefCell >= 0)

--- a/examples/neoPisoFoam/neoPisoFoam.cpp
+++ b/examples/neoPisoFoam/neoPisoFoam.cpp
@@ -153,6 +153,10 @@ int main(int argc, char* argv[])
                         rt
                     );
 
+                    // updateFaceVelocity reconstructs phi from this pressure system; keep the
+                    // non-orthogonal faceFluxCorrection so the reconstruction can add it back.
+                    pEqn.linearSystem().keepFaceFluxCorrection(true);
+
                     if (ofP.needReference() && pRefCell >= 0)
                     {
                         pEqn.setReference(pRefCell, pRefValue);

--- a/include/NeoFOAM/algorithms/pressureVelocityCoupling.hpp
+++ b/include/NeoFOAM/algorithms/pressureVelocityCoupling.hpp
@@ -57,7 +57,15 @@ std::tuple<nnfvcc::VolumeField<scalar>, nnfvcc::VolumeField<Vec3>>
 computeRAUandHByA(const PDESolver<Vec3>& expr);
 
 /* @brief computes phi = phiHbyA - pEqn.flux();
- * where pEqn.flux
+ * where pEqn.flux() = (orthogonal matrix-coefficient flux) + faceFluxCorrection
+ *
+ * @detail The pressure Laplacian defers its non-orthogonal snGrad correction to the matrix
+ * RHS (deferred correction) and stashes the per-face correction flux in the linear system
+ * (LinearSystem::faceFluxCorrection(), the OpenFOAM fvMatrix::faceFluxCorrectionPtr_ analogue).
+ * This reconstruction adds it back; the orthogonal-only reconstruction would otherwise leave
+ * div(phi) = div(correctionFlux) != 0, inflating the continuity error on non-orthogonal meshes
+ * while orthogonal / uncorrected meshes stay correct.
+ *
  * @note assumes an assembled system matrix
  */
 void updateFaceVelocity(

--- a/src/algorithms/pressureVelocityCoupling.cpp
+++ b/src/algorithms/pressureVelocityCoupling.cpp
@@ -142,6 +142,18 @@ void updateFaceVelocity(
     auto values = ls.matrix().values().view();
     auto [iPhi, iPredPhi] = views(phi.internalVector(), predictedPhi.internalVector());
 
+    // Deferred non-orthogonal correction flux (OpenFOAM fvMatrix::faceFluxCorrectionPtr_).
+    // The Laplacian assembly stashed the exact per-face correction it deferred to the RHS — using
+    // the field as it stood at assembly time — so adding it back here gives
+    // pEqn.flux() = orthogonal matrix-coefficient flux + faceFluxCorrection and div(phi) closes on
+    // non-orthogonal meshes. Reusing the stored value (rather than recomputing from the post-solve
+    // p) is what makes the closure exact, and avoids an extra snGrad evaluation. Null pointer ⇒
+    // orthogonal / uncorrected scheme ⇒ no correction.
+    const auto& ffcPtr = ls.faceFluxCorrection();
+    const bool hasCorrection = (ffcPtr != nullptr) && (ffcPtr->size() == nInternalFaces);
+    NeoN::Vector<scalar> noCorrection(exec, 0);
+    const auto ffc = hasCorrection ? ffcPtr->view() : noCorrection.view();
+
     // TODO add to NEON
     NeoN::parallelFor(
         exec,
@@ -156,7 +168,9 @@ void updateFaceVelocity(
             auto upper = values[rowNeiStart + neiOffs[facei]];
             auto lower = values[rowOwnStart + ownOffs[facei]];
 
-            iPhi[facei] = iPredPhi[facei] - (upper * internalP[nei] - lower * internalP[own]);
+            scalar corrFlux = hasCorrection ? ffc[facei] : scalar(0);
+            iPhi[facei] =
+                iPredPhi[facei] - (upper * internalP[nei] - lower * internalP[own]) - corrFlux;
         }
     );
 

--- a/test/test_distributedPressureVelocityCoupling.cpp
+++ b/test/test_distributedPressureVelocityCoupling.cpp
@@ -287,6 +287,9 @@ TEST_CASE("Distributed PressureVelocityCoupling")
             rt
         );
 
+        // updateFaceVelocity below reconstructs phi from this system; keep the faceFluxCorrection.
+        pEqn.linearSystem().keepFaceFluxCorrection(true);
+
         auto& solverDict = rt.fvSolutionDict.subDict("solvers");
         solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"));
 

--- a/test/test_pressureVelocityCoupling.cpp
+++ b/test/test_pressureVelocityCoupling.cpp
@@ -184,6 +184,9 @@ TEST_CASE("PressureVelocityCoupling")
             rt
         );
 
+        // updateFaceVelocity below reconstructs phi from this system; keep the faceFluxCorrection.
+        pEqn.linearSystem().keepFaceFluxCorrection(true);
+
         auto& solverDict = rt.fvSolutionDict.subDict("solvers");
         solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"));
 


### PR DESCRIPTION
updateFaceVelocity rebuilt phi from only the orthogonal matrix coefficients, dropping the OpenFOAM faceFluxCorrectionPtr_ term, so div(phi) carried the full non-orthogonal correction divergence and the time-step continuity error blew up on non-orthogonal meshes (orthogonal/uncorrected meshes were unaffected). Read the per-face correction the Laplacian assembly stashed in LinearSystem::faceFluxCorrection() and subtract it from the reconstructed flux.

Bumps src/NeoN to the matching faceFluxCorrection storage + sign-flip commit.