### PR TITLE
perf(PDESolver): reference cached LinearSystem instead of deep-copying

### DIFF
--- a/examples/neoPimpleFoam/neoPimpleFoam.cpp
+++ b/examples/neoPimpleFoam/neoPimpleFoam.cpp
@@ -65,11 +65,6 @@ int main(int argc, char* argv[])
         auto& p = nf::constructAndRegister(vectorCollection, rt, ofP, false);
         auto& U = nf::constructAndRegister(vectorCollection, rt, ofU, false);
 
-        // Gauss-Green gradient operator for the explicit deviatoric viscous-stress term.
-        // The full viscous term is div(nuEff*(grad(U) + grad(U)^T)) = laplacian(nuEff,U)
-        // + div(nuEff*dev2(T(grad(U)))); the implicit laplacian alone is not sufficient.
-        fvcc::GaussGreenGrad gradOp(rt.exec, rt.nfMesh);
-
         NeoN::Logging::info("Creating phi");
         auto& phi = nf::constructAndRegister(vectorCollection, rt, ofPhi, false);
 
@@ -78,11 +73,6 @@ int main(int argc, char* argv[])
         auto turb = nf::TurbulenceModel::create(rt, nu);
 
         turb->validate(U);
-
-        // Hoisted reuse buffer for the 2nd+ outer correctors' current-U velocity gradient,
-        // allocated ONCE here and refilled in place via gradTensor(U, localGradU) when needed —
-        // so no VolumeField<Tensor> (~nCells*9 scalars) is allocated per outer corrector.
-        auto localGradU = gradOp.gradTensor(U);
 
         // Hoist the surface interpolation once to avoid re-constructing it per inner corrector.
         auto surfInterpol = fvcc::SurfaceInterpolation<NeoN::scalar>(
@@ -136,19 +126,17 @@ int main(int argc, char* argv[])
                 // the internal vector) so we can blend against it after the pressure solve.
                 auto prevP = NeoN::dsl::fieldRelaxationSnapshot(p);
 
-                // On the first outer corrector reuse turb->gradU() (already at U^n) to avoid
-                // an extra grad(U) allocation; later correctors update localGradU in place.
-                const fvcc::VolumeField<NeoN::Tensor>* gradUPtr = nullptr;
-                if (pimpleLoop.firstIter())
+                // First outer corrector: reuse turb->gradU() (already grad(U^n) from the previous
+                // step's turb->correct(), proc-halo exchanged) — no recompute. Later correctors:
+                // refresh the turbulence model's single gradU buffer in place at the current U via
+                // updateGradU(), instead of allocating a separate VolumeField<Tensor> (~nCells*9
+                // scalars). Safe because turb->correct() recomputes gradU after the loop, so no
+                // turbulence state is corrupted.
+                if (!pimpleLoop.firstIter())
                 {
-                    gradUPtr = &turb->gradU();
+                    turb->updateGradU(U);
                 }
-                else
-                {
-                    gradOp.gradTensor(U, localGradU);
-                    gradUPtr = &localGradU;
-                }
-                const auto& gradU = *gradUPtr;
+                const auto& gradU = turb->gradU();
 
                 nf::PDE<NeoN::Vec3> UEqn(
                     dsl::imp::ddt(U) + dsl::imp::div(phi, U) - dsl::imp::laplacian(turb->nuEff(), U)

--- a/include/NeoFOAM/datastructures/pde.hpp
+++ b/include/NeoFOAM/datastructures/pde.hpp
@@ -45,7 +45,7 @@ public:
         : psi_(&psi)
         , expr_(expr)
         , runTime_(&runTime)
-        , ls_(readOrCreate<LinearSystem>(
+        , ls_(&readOrCreate<LinearSystem>(
               runTime,
               "linearSystem" + psi.name,
               // FIXME find a proper place
@@ -70,6 +70,7 @@ public:
               }
           ))
     {
+        markLsBorrowed();
         // TODO run NeoN expr_ = NeoN::dsl::optimize(expr); if optimize is set in fvSolution
         // NOTE OpenFOAM tokenizes a switch like 'optimize true;' as a word, so it is stored
         // as a std::string in the NeoN dictionary; reading it as bool throws bad_any_cast.
@@ -90,16 +91,19 @@ public:
         : psi_(nullptr)
         , expr_(std::move(expr))
         , runTime_(nullptr)
-        , ls_(std::nullopt)
+        , ls_(nullptr)
     {}
 
+    // Copies share the cached LinearSystem pointer without re-borrowing (ownsLsBorrow_ stays
+    // false), so only the original releases the borrow. Copies must not outlive / be used
+    // concurrently with the original — same one-live-per-field invariant as ls_.
     PDE(const PDE& expr)
         : psi_(expr.psi_)
         , expr_(expr.expr_)
         , runTime_(expr.runTime_)
         , ls_(expr.ls_) {};
 
-    ~PDE() = default;
+    ~PDE() { releaseLsBorrowIfOwned(); }
 
     VolumeField& getField() { return *psi_; }
 
@@ -428,7 +432,7 @@ private:
         }
         expr_.read(NeoFOAM::expandSchemeDefaults(rt.fvSchemesDict, expr_, psi.name));
 
-        ls_.emplace(readOrCreate<LinearSystem>(
+        ls_ = &readOrCreate<LinearSystem>(
             rt,
             "linearSystem" + psi.name,
             [&psi, &rt]()
@@ -450,7 +454,49 @@ private:
                     );
                 }
             }
-        ));
+        );
+        markLsBorrowed();
+    }
+
+    // Mark this PDESolver as the borrower of its field's cached LinearSystem. In debug builds a
+    // per-field flag in controlDict asserts that no other live PDESolver already holds it (the
+    // system is assembled in place; two concurrent borrowers would corrupt it). Release builds
+    // only set ownsLsBorrow_ (zero overhead beyond the bool).
+    void markLsBorrowed()
+    {
+        ownsLsBorrow_ = true;
+#ifdef NF_DEBUG
+        const std::string key = "linearSystem" + psi_->name + "::borrowed";
+        auto initFalse = []() { return false; };
+        bool& borrowed = readOrCreate<bool>(*runTime_, key, initFalse);
+        NF_ASSERT(
+            !borrowed,
+            "PDESolver: this field's cached LinearSystem is already borrowed by another live "
+            "PDESolver. At most one PDESolver per field may be live at a time (it is assembled in "
+            "place)."
+        );
+        borrowed = true;
+#endif
+    }
+
+    // Release the borrow on destruction so the next PDESolver for the same field may take it.
+    void releaseLsBorrowIfOwned()
+    {
+        if (!ownsLsBorrow_)
+        {
+            return;
+        }
+        ownsLsBorrow_ = false;
+#ifdef NF_DEBUG
+        if (runTime_ != nullptr && psi_ != nullptr)
+        {
+            const std::string key = "linearSystem" + psi_->name + "::borrowed";
+            if (runTime_->controlDict.contains(key))
+            {
+                runTime_->controlDict.template get<bool>(key) = false;
+            }
+        }
+#endif
     }
 
     // Per-component name (Ux/Uy/Uz) when a vector field is solved as separate
@@ -493,7 +539,20 @@ private:
     VolumeField* psi_;
     dsl::Expression<ValueType> expr_;
     RunTime* runTime_;
-    std::optional<LinearSystem> ls_;
+    // Non-owning pointer into the single LinearSystem cached in RunTime::controlDict (keyed per
+    // field by readOrCreate). PDESolver assembles/relaxes/solves it IN PLACE instead of copying
+    // it, so there is exactly one LinearSystem per field — not an idle dict template plus a
+    // per-solver deep copy of the value/rhs/boundary buffers (~1.4 GB for a Vec3 momentum system
+    // at 18M cells). The cached system outlives every PDESolver (controlDict lives in RunTime) and
+    // its address is stable (controlDict is a node-based std::unordered_map and the entry is never
+    // erased). INVARIANT: at most one PDESolver per field may be live at a time — it is assembled
+    // in place, so two concurrent borrowers would corrupt each other's matrix. This holds for the
+    // segregated PISO/PIMPLE/SA solvers (U, p, nuTilda are each solved one at a time) and is
+    // checked by a debug borrow guard (markLsBorrowed/releaseLsBorrowIfOwned).
+    LinearSystem* ls_ = nullptr;
+    // True when this instance acquired the borrow (so its destructor releases it). Copies share
+    // the pointer without re-borrowing.
+    bool ownsLsBorrow_ = false;
     bool needReference_ = false;
     NeoN::localIdx pRefCell_ = 0;
     NeoN::scalar pRefValue_ = 0.0;

--- a/include/NeoFOAM/turbulenceModels/laminar.hpp
+++ b/include/NeoFOAM/turbulenceModels/laminar.hpp
@@ -38,6 +38,8 @@ public:
 
     const nnfvcc::VolumeField<NeoN::Tensor>& gradU() const override;
 
+    void updateGradU(const nnfvcc::VolumeField<NeoN::Vec3>& U) override;
+
     void rotateOldTimes() override {}
 
     void write(MeshAdapter&) const override {}

--- a/include/NeoFOAM/turbulenceModels/spalartAllmarasDDES.hpp
+++ b/include/NeoFOAM/turbulenceModels/spalartAllmarasDDES.hpp
@@ -139,6 +139,9 @@ public:
     /// @brief Velocity gradient tensor (updated each correct() call, for viscousStress term)
     const nnfvcc::VolumeField<NeoN::Tensor>& gradU() const override;
 
+    /// @brief Recompute gradU_ in place at U (+ proc-halo exchange); see TurbulenceModel.
+    void updateGradU(const nnfvcc::VolumeField<NeoN::Vec3>& U) override;
+
     void initialize(
         const nnfvcc::VolumeField<scalar>& nuTildaInit,
         const nnfvcc::VolumeField<scalar>& nutInit

--- a/include/NeoFOAM/turbulenceModels/turbulenceModel.hpp
+++ b/include/NeoFOAM/turbulenceModels/turbulenceModel.hpp
@@ -72,6 +72,14 @@ public:
     // Velocity gradient tensor updated each correct() call.
     virtual const nnfvcc::VolumeField<NeoN::Tensor>& gradU() const = 0;
 
+    // Recompute the model-owned gradU in place at the given velocity (internal + boundary +
+    // proc-halo exchange). Lets the PIMPLE outer loop refresh gradU for its 2nd+ correctors by
+    // reusing this one buffer instead of allocating a separate VolumeField<Tensor> (~nCells*9
+    // scalars) per solver. Safe because correct() recomputes gradU afterwards, so no turbulence
+    // state is corrupted, and the first corrector still reads the U^n gradU() left by the previous
+    // step's correct().
+    virtual void updateGradU(const nnfvcc::VolumeField<NeoN::Vec3>& U) = 0;
+
     // Rotate time-dependent fields for BDF2 time advancement.
     virtual void rotateOldTimes() = 0;
 

--- a/src/turbulenceModels/laminar.cpp
+++ b/src/turbulenceModels/laminar.cpp
@@ -34,18 +34,22 @@ Laminar::Laminar(RunTime& rt, const nnfvcc::VolumeField<NeoN::scalar>& nu)
     , surfInterp_(rt.exec, rt.nfMesh, NeoN::TokenList({std::string("linear")}))
 {}
 
-void Laminar::validate(const nnfvcc::VolumeField<NeoN::Vec3>& U)
+void Laminar::updateGradU(const nnfvcc::VolumeField<NeoN::Vec3>& U)
 {
     gradOp_.gradTensor(U, gradU_);
     gradU_.correctBoundaryConditions();
+}
+
+void Laminar::validate(const nnfvcc::VolumeField<NeoN::Vec3>& U)
+{
+    updateGradU(U);
     surfInterp_.interpolate(nu_, nuEff_);
 }
 
 void Laminar::
     correct(const nnfvcc::VolumeField<NeoN::Vec3>& U, nnfvcc::SurfaceField<NeoN::scalar>&, RunTime&)
 {
-    gradOp_.gradTensor(U, gradU_);
-    gradU_.correctBoundaryConditions();
+    updateGradU(U);
     surfInterp_.interpolate(nu_, nuEff_);
 }
 

--- a/src/turbulenceModels/spalartAllmarasDDES.cpp
+++ b/src/turbulenceModels/spalartAllmarasDDES.cpp
@@ -435,10 +435,7 @@ void SpalartAllmarasDDES::validate(
     nnfvcc::VolumeField<scalar>& nut
 )
 {
-    gradOp_.gradTensor(U, gradU_);
-    // Exchange the neighbour-cell gradient into gradU's processor tail (proc patches carry the
-    // processor BC; physical patches are 'calculated' no-ops, so their boundary gradient is kept).
-    gradU_.correctBoundaryConditions();
+    updateGradU(U);
 
     nnfvcc::SurfaceField<scalar> surfNut(
         exec_,
@@ -465,9 +462,7 @@ void SpalartAllmarasDDES::correct(
     RunTime& rt
 )
 {
-    gradOp_.gradTensor(U, gradU_);
-    // Exchange the neighbour-cell gradient into gradU's processor tail (see validate()).
-    gradU_.correctBoundaryConditions();
+    updateGradU(U);
 
     nnfvcc::VolumeField<Vec3> gradNuTilda(
         exec_,
@@ -549,6 +544,14 @@ nnfvcc::SurfaceField<scalar>& SpalartAllmarasDDES::nuEff() { return nuEff_; }
 const nnfvcc::VolumeField<scalar>& SpalartAllmarasDDES::nut() const { return nut_; }
 
 const nnfvcc::VolumeField<Tensor>& SpalartAllmarasDDES::gradU() const { return gradU_; }
+
+void SpalartAllmarasDDES::updateGradU(const nnfvcc::VolumeField<Vec3>& U)
+{
+    gradOp_.gradTensor(U, gradU_);
+    // Exchange the neighbour-cell gradient into gradU's processor tail (proc patches carry the
+    // processor BC; physical patches are 'calculated' no-ops, so their boundary gradient is kept).
+    gradU_.correctBoundaryConditions();
+}
 
 void SpalartAllmarasDDES::initialize(
     const nnfvcc::VolumeField<scalar>& nuTildaInit,


### PR DESCRIPTION
readOrCreate caches one full LinearSystem per field in RunTime::controlDict and returns a reference, but ls_ was a std::optional<LinearSystem> — so every PDESolver deep-copied the cached system's value/rhs/boundary buffers, leaving the dict copy permanently idle. At 18M cells that idle template plus the per-solver copy is ~3.6 GB across U/p/nuTilda.

Make ls_ a non-owning LinearSystem* into the dict-cached system and assemble/relax/solve it IN PLACE, so there is exactly one LinearSystem per field (the cached one is now the working system, not an idle template) and no per-construction value-buffer copy. The cached system outlives every PDESolver (controlDict lives in RunTime) and its address is stable (node-based std::unordered_map, entry never erased). Sparsity is still shared via the cached system's shared_ptr, so createEmptyLinearSystem is not re-run per construction.

INVARIANT: at most one PDESolver per field may be live at a time (assembled in place; two concurrent borrowers would corrupt each other). True for the segregated PISO/PIMPLE/SA solvers (U, p, nuTilda each solved one at a time). Guarded in debug by a per-field borrow flag (markLsBorrowed/releaseLsBorrowIfOwned, NF_DEBUG only). All assemble/solve paths reset() the system first, so in-place reuse across iterations starts from zero.

Follow-up (item #2-B from the GPU-memory audit): cache only the shared sparsity and have PDESolver own its LinearSystem, so a field's matrix is not resident when it is not being solved (lower PISO-time peak; mirrors the shared-sparsity-pattern work).