### PR TITLE
build: fix umpire/camp install RPATH so libcamp loads from the wheel layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,24 @@ if(DEFINED SKBUILD AND TARGET _neon)
   set_target_properties(_neon PROPERTIES INSTALL_RPATH "$ORIGIN/../neofoam/lib;$ORIGIN/../lib")
 endif()
 
+# Umpire/camp are CPM deps added inside src/NeoN, where NeoN sets CMAKE_INSTALL_RPATH to the
+# absolute install prefix /lib (the wheel-staging temp dir under SKBUILD). That path is gone after
+# install, so libumpire.so cannot find its direct dependency libcamp.so at import (camp/cpptrace
+# "leak" to the site-packages root lib/). Re-point them at the installed layout with $ORIGIN-
+# relative entries: from neofoam/lib, $ORIGIN reaches its siblings and $ORIGIN/../../lib reaches the
+# site-packages root lib/ where camp lives. This only rewrites the install RPATH (a relink), so it
+# does not trigger a recompile.
+if(DEFINED SKBUILD)
+  foreach(_leaked_dep umpire camp)
+    if(TARGET ${_leaked_dep})
+      set_target_properties(
+        ${_leaked_dep}
+        PROPERTIES INSTALL_RPATH "$ORIGIN;$ORIGIN/lib;$ORIGIN/../lib;$ORIGIN/../../lib"
+                   INSTALL_RPATH_USE_LINK_PATH FALSE)
+    endif()
+  endforeach()
+endif()
+
 add_subdirectory(include)
 add_subdirectory(src)
 


### PR DESCRIPTION
## Problem

After "install all native artifacts under `neofoam/`", importing the native
bindings fails unless `LD_LIBRARY_PATH` is set by hand:

```
ImportError: libcamp.so: cannot open shared object file: No such file or directory
```

**Root cause:** `src/NeoN/CMakeLists.txt` sets `CMAKE_INSTALL_RPATH` to
`${CMAKE_INSTALL_PREFIX}/lib`, which under scikit-build is the wheel-staging
**temp directory**. The umpire/camp CPM targets (added inside `src/NeoN`) inherit
it, so `libumpire.so` ends up with a dead absolute path as its RUNPATH:

```
$ readelf -d .../neofoam/lib/libumpire.so | grep RUNPATH
RUNPATH  [/tmp/tmpXXXX/wheel/platlib/lib]
```

That dir is gone after install, and RUNPATH does not apply to *transitive*
dependencies, so `libumpire.so` can't find its direct dependency `libcamp.so`
(camp/cpptrace install to the site-packages **root** `lib/`, not `neofoam/lib`).

## Fix

Re-point the `umpire`/`camp` targets at the installed layout with
`$ORIGIN`-relative `INSTALL_RPATH` entries. From `neofoam/lib`,
`$ORIGIN/../../lib` reaches the site-packages root `lib/` where camp/cpptrace
land. This only rewrites the install RPATH (a relink) — **no recompile**.

## Verification

After this change `libumpire.so`'s RUNPATH is `$ORIGIN:$ORIGIN/lib:$ORIGIN/../lib:$ORIGIN/../../lib`
and the bindings import with only OpenFOAM sourced (no manual `LD_LIBRARY_PATH`):

```python
>>> import neon._neon            # was: ImportError libcamp.so
>>> from neofoam import neofoam_bindings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
