### PR TITLE
feat(solver): declare the case-authoring surface for incompressibleVoF & incompressibleFluidNeoN

### DIFF
--- a/src/neofoam/solver/incompressibleFluidNeoN/incompressibleFluidNeoN.py
+++ b/src/neofoam/solver/incompressibleFluidNeoN/incompressibleFluidNeoN.py
@@ -25,8 +25,13 @@ from neofoam.framework.operations import (
     StepBuilder,
 )
 from neofoam.framework.solver import Solver
+from neofoam.framework.tools import PreprocessConfig
 from neofoam.framework.types import OperationMetadata
 from neofoam.solver.neon_runtime import ensure_neon_initialized
+from neofoam.tools.block_mesh import BlockMeshDictConfig
+from neofoam.tools.snappy_hex_mesh import SnappyHexMeshDictConfig
+from neofoam.turbulence.config import TurbulencePropertiesConfig
+from neofoam.viscosity.config import TransportPropertiesConfig
 
 from .configs import ControlDictConfig
 from .create_fields import create_init
@@ -47,10 +52,22 @@ def _core_model(state: Any, spec_name: str) -> Any:
 incompressibleFluidNeoN = Solver("incompressibleFluidNeoN")
 
 # Declare the full config schema on the spec, case-free: the solver's own
-# configs plus the model families it owns. Viscosity/turbulence carry no
-# Python config classes — the NeoN C++ factories read
-# constant/transportProperties / constant/turbulenceProperties directly.
+# configs plus the model families it owns.
 incompressibleFluidNeoN.config(ControlDictConfig)
+incompressibleFluidNeoN.config(
+    PreprocessConfig
+)  # mesh pipeline enable file (configs())
+# The two mesh-input dicts: writer configs so the wizard/MCP fill and persist them
+# like any other case file (blockMesh/snappyHexMesh read them at launch) — without
+# them the sweep's mesh dimension is unavailable.
+incompressibleFluidNeoN.config(BlockMeshDictConfig)
+incompressibleFluidNeoN.config(SnappyHexMeshDictConfig)
+# The NeoN C++ factories read constant/transportProperties /
+# constant/turbulenceProperties directly at solve time; declaring the (single-phase)
+# Python config classes here does not change that — it only surfaces the two
+# mandatory files in the case-authoring schema so the wizard/agent fills them.
+incompressibleFluidNeoN.config(TransportPropertiesConfig)  # molecular nu
+incompressibleFluidNeoN.config(TurbulencePropertiesConfig)  # simulationType
 
 incompressibleFluidNeoN.models(PressureVelocityAlgorithmNeoN, required=True)  # pick ONE
 incompressibleFluidNeoN.models(incompressibleFluidNeoNModel)  # optional: zero or more

--- a/src/neofoam/solver/incompressibleFluidNeoN/models/pressure_velocity/pimpleAlgorithm.py
+++ b/src/neofoam/solver/incompressibleFluidNeoN/models/pressure_velocity/pimpleAlgorithm.py
@@ -260,6 +260,10 @@ def rotate_and_report(
     div=["div(phi,U)", "div((nuEff*dev2(T(grad(U)))))"],
     grad="grad(U)",
     laplacian="laplacian(nuEff,U)",
+    # ``flux(U)`` builds the initial face flux phi (``nfb.create_phi``); the NeoN
+    # runtime looks it up in interpolationSchemes, so it must be declared or the
+    # case aborts with *Entry 'flux(U)' not found*.
+    interpolation="flux(U)",
 )
 @PimpleNeoNFvSolution.add("U")
 def momentum(

--- a/src/neofoam/solver/incompressibleVoF/configs.py
+++ b/src/neofoam/solver/incompressibleVoF/configs.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 NeoFOAM authors
+
+"""Solver-core configs for incompressibleVoF (interFoam-style two-phase VoF).
+
+These pydantic ``BaseConfig`` classes declare the case-authoring surface the
+solver's C++ backend reads at run time but that no model family already owns:
+
+- :class:`ControlDictConfig` — ``system/controlDict`` with the interFoam
+  adaptive-stepping keys (``adjustTimeStep`` / ``maxCo`` / ``maxAlphaCo`` /
+  ``maxDeltaT``) that ``set_time_step`` re-reads every step.
+- :class:`TransportPropertiesConfig` — the **two-phase** ``constant/
+  transportProperties`` (``phases`` + per-phase ``transportModel`` / ``nu`` /
+  ``rho`` + ``sigma``) that the C++ ``immiscibleIncompressibleTwoPhaseMixture``
+  constructor reads. Single-phase transport configs
+  (:class:`neofoam.viscosity.config.TransportPropertiesConfig`,
+  ``BoussinesqConfig``) do not model ``phases``/``sigma``, so VoF needs its own.
+- :class:`GravityConfig` — ``constant/g`` (buoyant pressure needs gravity).
+
+:class:`~neofoam.turbulence.config.TurbulencePropertiesConfig` is re-exported so
+the solver can declare it without importing the turbulence package by path; the
+two-phase ``TwoPhaseTransportModel`` reads ``constant/turbulenceProperties``.
+
+None of these change the solve: they are declared on the solver spec purely so
+``configurations(incompressibleVoF)`` / the case wizard can fill and persist the
+files the C++ backend then reads.
+"""
+
+from typing import Any
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+)
+
+from neofoam.algorithms.solution_loop.config import TimeControlConfig
+from neofoam.io import OF, BaseConfig, IOStrategy
+from neofoam.turbulence.config import TurbulencePropertiesConfig
+
+__all__ = [
+    "ControlDictConfig",
+    "TransportPropertiesConfig",
+    "GravityConfig",
+    "TurbulencePropertiesConfig",
+]
+
+
+@IOStrategy(OF("system/controlDict"))
+class ControlDictConfig(TimeControlConfig):
+    """``system/controlDict`` — the file-bound time/write config for VoF.
+
+    Inherits the time-stepping + write schema (``startTime`` / ``endTime`` /
+    ``deltaT`` / ``writeControl`` / ``writeInterval``) from
+    :class:`~neofoam.algorithms.solution_loop.config.TimeControlConfig`.
+
+    Unlike ``incompressibleFluid`` (which co-owns the adaptive keys through
+    opt-in ``courant`` / ``max_delta_t`` models), VoF's ``set_time_step`` re-reads
+    ``adjustTimeStep`` / ``maxCo`` / ``maxAlphaCo`` / ``maxDeltaT`` from
+    ``controlDict`` every step (the dual flow/interface Courant limiter is core to
+    interFoam), so they live here with interFoam-typical defaults.
+    """
+
+    application: str = "interFoam"
+    adjustTimeStep: bool = False
+    maxCo: float = 1.0
+    maxAlphaCo: float = 1.0
+    maxDeltaT: float = 1.0
+
+
+class PhaseTransport(BaseModel):
+    """One phase's transport sub-dict in ``constant/transportProperties``.
+
+    ``transportModel Newtonian; nu <kinematic viscosity>; rho <density>;`` — the
+    interFoam per-phase block. ``nu`` is a kinematic viscosity (m^2/s), ``rho`` a
+    density (kg/m^3).
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    transportModel: str = "Newtonian"
+    nu: float
+    rho: float
+
+
+@IOStrategy(OF("constant/transportProperties"))
+class TransportPropertiesConfig(BaseConfig):
+    """``constant/transportProperties`` — the interFoam two-phase transport.
+
+    Models the file the C++ ``immiscibleIncompressibleTwoPhaseMixture`` reads:
+    the ordered ``phases`` list, one transport sub-dict per phase, and the
+    surface-tension coefficient ``sigma``. Defaults describe water flooding an
+    air-filled domain (the hx-cad VoF study).
+    """
+
+    phases: list[str] = Field(default_factory=lambda: ["water", "air"])
+    water: PhaseTransport = Field(
+        default_factory=lambda: PhaseTransport(nu=1e-6, rho=1000.0)
+    )
+    air: PhaseTransport = Field(
+        default_factory=lambda: PhaseTransport(nu=1.48e-5, rho=1.0)
+    )
+    sigma: float = 0.07
+
+    @field_serializer("phases", when_used="always")
+    def _serialize_phases(self, value: list[str]) -> str:
+        return "(" + " ".join(value) + ")"
+
+    @field_validator("phases", mode="before")
+    @classmethod
+    def _parse_phases(cls, value: Any) -> list[str]:
+        if isinstance(value, str):
+            return value.strip().strip("()").split()
+        return list(value)
+
+
+class _GravityHeader(BaseModel):
+    """The ``FoamFile`` header that identifies ``constant/g`` to OpenFOAM.
+
+    ``class`` is pinned to ``uniformDimensionedVectorField`` so OpenFOAM reads the
+    file as a gravity field (not the generic ``dictionary`` the writer injects for
+    headerless configs).
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    version: str = "2.0"
+    format: str = "ascii"
+    field_class: str = Field(default="uniformDimensionedVectorField", alias="class")
+    object: str = "g"
+
+
+def _fmt_component(x: float) -> str:
+    """Render a vector component with no gratuitous ``.0`` (``0.0`` -> ``0``)."""
+    return str(int(x)) if x == int(x) else repr(x)
+
+
+@IOStrategy(OF("constant/g"))
+class GravityConfig(BaseConfig):
+    """``constant/g`` — the uniform gravitational acceleration.
+
+    The VoF ``p_rgh`` formulation reads ``g`` at init to form the geopotential
+    ``gh`` / ``ghf``; without this file the solver aborts with *cannot find file
+    "constant/g"*. Defaults are Earth gravity acting in -y: ``dimensions
+    [0 1 -2 0 0 0 0]``, ``value (0 -9.81 0)``.
+
+    A field-for-field copy of ``incompressibleFluid``'s ``GravityConfig``; the two
+    are unified in a neutral module as a follow-up (the VoF review branch keeps its
+    solver package self-contained).
+    """
+
+    FoamFile: _GravityHeader = Field(default_factory=_GravityHeader)
+    dimensions: list[int] = Field(default_factory=lambda: [0, 1, -2, 0, 0, 0, 0])
+    value: list[float] = Field(default_factory=lambda: [0.0, -9.81, 0.0])
+
+    @field_validator("dimensions", mode="before")
+    @classmethod
+    def _parse_dimensions(cls, value: Any) -> list[int]:
+        if isinstance(value, str):
+            return [int(p) for p in value.strip().strip("[]").split()]
+        return [int(v) for v in value]
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_value(cls, value: Any) -> list[float]:
+        if isinstance(value, str):
+            return [float(p) for p in value.strip().strip("()").split()]
+        return [float(v) for v in value]
+
+    @field_serializer("dimensions", when_used="always")
+    def _serialize_dimensions(self, value: list[int]) -> str:
+        return "[" + " ".join(str(int(v)) for v in value) + "]"
+
+    @field_serializer("value", when_used="always")
+    def _serialize_value(self, value: list[float]) -> str:
+        return "(" + " ".join(_fmt_component(v) for v in value) + ")"

--- a/src/neofoam/solver/incompressibleVoF/incompressibleVoF.py
+++ b/src/neofoam/solver/incompressibleVoF/incompressibleVoF.py
@@ -36,10 +36,20 @@ from neofoam.framework.operations import (
     StepBuilder,
 )
 from neofoam.framework.solver import Solver
+from neofoam.framework.tools import PreprocessConfig
 from neofoam.framework.types import OperationMetadata
+from neofoam.tools.block_mesh import BlockMeshDictConfig
+from neofoam.tools.snappy_hex_mesh import SnappyHexMeshDictConfig
 
+from .configs import (
+    ControlDictConfig,
+    GravityConfig,
+    TransportPropertiesConfig,
+    TurbulencePropertiesConfig,
+)
 from .create_fields import create_init
-from .models.alpha_advection.advectionModel import advectionModel
+from .models.alpha_advection import advectionModel  # noqa: F401 (registers members)
+from .models.incompressibleVoFModel import incompressibleVoFModel
 from .models.pressure_velocity.base import PressureVelocityAlgorithm
 
 
@@ -97,6 +107,26 @@ def _core_spec(state: Any, names: set[str]) -> Any:
 
 
 incompressibleVoF = Solver("incompressibleVoF")
+
+# Declare the full case-authoring schema on the spec, case-free (mirrors
+# ``incompressibleFluid``): the solver's own configs plus the model families it
+# owns. Every member's configs/fields join the schema; per-case detection (in
+# create_fields) still picks which members run. Two-phase transport, gravity and
+# turbulence are read by the C++ backend directly, so they are declared as solver
+# configs (VoF has no single-phase viscosity/turbulence model families).
+incompressibleVoF.config(ControlDictConfig)
+incompressibleVoF.config(PreprocessConfig)  # mesh pipeline enable file (configs())
+# The two mesh-input dicts: writer configs so the wizard/MCP fill and persist them
+# like any other case file (blockMesh/snappyHexMesh read them at launch).
+incompressibleVoF.config(BlockMeshDictConfig)
+incompressibleVoF.config(SnappyHexMeshDictConfig)
+incompressibleVoF.config(TransportPropertiesConfig)  # two-phase phases/nu/rho/sigma
+incompressibleVoF.config(GravityConfig)  # constant/g
+incompressibleVoF.config(TurbulencePropertiesConfig)  # simulationType
+
+incompressibleVoF.models(advectionModel, required=True)  # alpha advection (pick ONE)
+incompressibleVoF.models(PressureVelocityAlgorithm, required=True)  # VoF PIMPLE
+incompressibleVoF.models(incompressibleVoFModel)  # optional: zero or more
 
 
 @incompressibleVoF.initializer

--- a/src/neofoam/solver/incompressibleVoF/models/alpha_advection/models/mules.py
+++ b/src/neofoam/solver/incompressibleVoF/models/alpha_advection/models/mules.py
@@ -35,6 +35,18 @@ from pybFoam import (
     volScalarField,
 )
 
+from neofoam.fields import (
+    CyclicBC,
+    EmptyBC,
+    FixedValueBC,
+    GenericBC,
+    InletOutletBC,
+    Scalar,
+    SymmetryBC,
+    SymmetryPlaneBC,
+    ZeroGradientBC,
+)
+from neofoam.foam import fvSchemes, fvSolution
 from neofoam.framework.context import FieldUpdates
 from neofoam.framework.operations import (
     Operation,
@@ -49,6 +61,32 @@ from ..shared import MixtureProtocol, shared_field_build_steps
 __all__ = ["mules"]
 
 mules = Model("MULES").register_with(advectionModel).labeled("MULES")
+
+# Per-spec fvSchemes / fvSolution slices + the ``0/alpha.water`` field the wizard
+# authors. Schema-only (surfaced through ``configurations(solver)``); the alpha
+# field is created at run time from the C++ mixture (``shared_field_build_steps``),
+# so declaring it here changes no init behaviour. ``alpha.water`` is declared on
+# MULES alone (the default advection scheme) so it surfaces exactly once even
+# though every advection member owns the same field.
+MulesFvSchemes = mules.config(fvSchemes)
+MulesFvSolution = mules.config(fvSolution)
+
+mules.field(
+    "alpha.water",
+    dimensions=[0, 0, 0, 0, 0, 0, 0],
+    value_type=Scalar,
+    allowed_bcs=[
+        FixedValueBC,
+        ZeroGradientBC,
+        InletOutletBC,
+        EmptyBC,
+        SymmetryBC,
+        SymmetryPlaneBC,
+        CyclicBC,
+        GenericBC,
+    ],
+    write=True,
+)
 
 
 # Scheme names, resolved from fvSchemes divSchemes (mirrors alphaEqn.H).
@@ -279,6 +317,12 @@ def _solve_alpha_python(
 
 
 @mules.operation(operation_number="2.0")
+@MulesFvSchemes.add(
+    ddt="ddt(alpha1)",
+    # scheme-based phase flux + interface-compression flux (alphaEqn.H).
+    div=["div(phi,alpha)", "div(phirb,alpha)"],
+)
+@MulesFvSolution.add("alpha.water")
 def alpha_advection(
     alpha1: volScalarField,
     alpha2: volScalarField,

--- a/src/neofoam/solver/incompressibleVoF/models/pressure_velocity/pimpleAlgorithm.py
+++ b/src/neofoam/solver/incompressibleVoF/models/pressure_velocity/pimpleAlgorithm.py
@@ -26,6 +26,24 @@ from pybFoam import (
 )
 
 from neofoam.algorithms.solution_loop.control import PimpleControl
+from neofoam.fields import (
+    CalculatedBC,
+    CyclicBC,
+    EmptyBC,
+    FixedFluxPressureBC,
+    FixedValueBC,
+    GenericBC,
+    InletOutletBC,
+    NoSlipBC,
+    PressureInletOutletVelocityBC,
+    Scalar,
+    SlipBC,
+    SymmetryBC,
+    SymmetryPlaneBC,
+    Vector,
+    ZeroGradientBC,
+)
+from neofoam.foam import fvSchemes, fvSolution
 from neofoam.foam.initialization import read_vol_field
 from neofoam.framework.context import Context, FieldUpdates
 from neofoam.framework.initialization import field, model
@@ -41,6 +59,66 @@ from ..alpha_advection.shared import MixtureProtocol
 from ..incompressibleVoFModel import Model
 
 pimple = Model("Pimple")
+
+# Per-spec fvSchemes / fvSolution slices — schema-only, surfaced through
+# ``configurations(solver)`` so the case wizard / agent fills the case scaffold.
+# Operations extend these via ``@PimpleFvSchemes.add(...)`` /
+# ``@PimpleFvSolution.add(...)`` below. Declaring them does not change the solve:
+# ``ModelSpec.build_steps`` runs only the ``@pimple.build`` function, never the
+# field/config declarations, so the fields are still read by ``@build`` at run
+# time exactly as before.
+PimpleFvSchemes = pimple.config(fvSchemes)
+PimpleFvSolution = pimple.config(fvSolution)
+
+# Optional PIMPLE control keys read straight from ``system/fvSolution`` by
+# ``setRefCell`` (see ``create_pressure_reference``): a closed domain (no
+# fixed-pressure BC) needs a pressure reference, an open one does not.
+PimpleFvSolution.add_controls("PIMPLE", pRefCell=int, pRefValue=float)
+
+# 0/<name> field declarations PIMPLE owns for the wizard: velocity ``U`` and the
+# buoyant (dynamic) pressure ``p_rgh`` — the fields the case author fills BCs for.
+# The absolute pressure ``p`` is derived (``p = p_rgh + rho*gh``) so it is not a
+# separate authoring surface; ``alpha.water`` is owned by the advection family.
+pimple.field(
+    "U",
+    dimensions=[0, 1, -1, 0, 0, 0, 0],
+    value_type=Vector,
+    allowed_bcs=[
+        NoSlipBC,
+        FixedValueBC,
+        ZeroGradientBC,
+        SlipBC,
+        InletOutletBC,
+        PressureInletOutletVelocityBC,
+        EmptyBC,
+        SymmetryBC,
+        SymmetryPlaneBC,
+        CyclicBC,
+        GenericBC,
+    ],
+    write=True,
+)
+pimple.field(
+    "p_rgh",
+    dimensions=[1, -1, -2, 0, 0, 0, 0],
+    value_type=Scalar,
+    # Buoyant pressure: fixedFluxPressure dominates on walls/tubes, fixedValue
+    # at the outlet, inletOutlet/calculated round out the survey; topology arms
+    # cover thin / periodic cases.
+    allowed_bcs=[
+        FixedFluxPressureBC,
+        FixedValueBC,
+        ZeroGradientBC,
+        InletOutletBC,
+        CalculatedBC,
+        EmptyBC,
+        SymmetryBC,
+        SymmetryPlaneBC,
+        CyclicBC,
+        GenericBC,
+    ],
+    write=True,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -175,6 +253,16 @@ def _alias_operation(
 
 
 @pimple.operation(operation_number="2.1")
+@PimpleFvSchemes.add(
+    ddt="ddt(U)",
+    # density-weighted convection + the viscous-stress divergence from
+    # ``divDevRhoReff(rho, U)``.
+    div=["div(rhoPhi,U)", "div(((rho*nuEff)*dev2(T(grad(U)))))"],
+    grad="grad(U)",
+    laplacian="laplacian(nuEff,U)",
+    snGrad=["snGrad(rho)", "snGrad(p_rgh)"],
+)
+@PimpleFvSolution.add("U")
 def momentum(
     U: volVectorField,
     rho: volScalarField,
@@ -211,6 +299,13 @@ def momentum(
 
 
 @pimple.operation(operation_number="2.2", depends_on=["momentum"])
+@PimpleFvSchemes.add(
+    grad="grad(p_rgh)",
+    laplacian="laplacian(rAUf,p_rgh)",
+    interpolation=["flux(HbyA)", "interpolate(rho*rAU)"],
+    snGrad=["snGrad(p_rgh)", "snGrad(rho)"],
+)
+@PimpleFvSolution.add("p_rgh")
 def continuity(
     U: volVectorField,
     rho: volScalarField,

--- a/src/neofoam/solver/incompressibleVoF/models/pressure_velocity/pimpleAlgorithm.py
+++ b/src/neofoam/solver/incompressibleVoF/models/pressure_velocity/pimpleAlgorithm.py
@@ -75,6 +75,21 @@ PimpleFvSolution = pimple.config(fvSolution)
 # fixed-pressure BC) needs a pressure reference, an open one does not.
 PimpleFvSolution.add_controls("PIMPLE", pRefCell=int, pRefValue=float)
 
+# Section ``default`` schemes — interFoam's ``interfaceProperties`` resolves the
+# interface-normal gradient through a ``nHat`` gradScheme and makes several other
+# unnamed scheme lookups (curvature / surface-tension interpolation) that fall
+# back to the section default. Without these, a wizard-authored VoF case (explicit
+# entries only) aborts with *Entry 'nHat' not found in gradSchemes*. ``div`` is
+# left out on purpose: interFoam keeps ``divSchemes default none`` so every
+# convection term must be declared explicitly (they are, above).
+PimpleFvSchemes.add(
+    ddt="default",
+    grad="default",
+    laplacian="default",
+    snGrad="default",
+    interpolation="default",
+)
+
 # 0/<name> field declarations PIMPLE owns for the wizard: velocity ``U`` and the
 # buoyant (dynamic) pressure ``p_rgh`` — the fields the case author fills BCs for.
 # The absolute pressure ``p`` is derived (``p = p_rgh + rho*gh``) so it is not a
@@ -302,7 +317,10 @@ def momentum(
 @PimpleFvSchemes.add(
     grad="grad(p_rgh)",
     laplacian="laplacian(rAUf,p_rgh)",
-    interpolation=["flux(HbyA)", "interpolate(rho*rAU)"],
+    # ``flux(U)`` builds the initial face flux phi (``createPhi(U)`` in the
+    # advection shared build); OpenFOAM looks it up in interpolationSchemes, so it
+    # must be declared or the case aborts *Entry 'flux(U)' not found*.
+    interpolation=["flux(U)", "flux(HbyA)", "interpolate(rho*rAU)"],
     snGrad=["snGrad(p_rgh)", "snGrad(rho)"],
 )
 @PimpleFvSolution.add("p_rgh")


### PR DESCRIPTION
## What

Makes the case **wizard** work for the `incompressibleVoF` and `incompressibleFluidNeoN` solvers, not just `incompressibleFluid`, by declaring on each `Solver` spec the config / model / field schema the wizard renders (`configurations()` / `model_catalog()` / `build_forms()`).

Split out from the `feat/e2eWorkflow` genericity probe so the **solver-side changes review independently**. Scope is deliberately limited to the two solver packages — the registry/CLI enablement and the generic validation/scaffold/UI work live elsewhere.

## Why

A genericity probe of the wizard (drive `run_study_reliable.py` for each registered solver) found the wizard machinery is solver-agnostic but the two solvers **under-declared their authoring surface**:

- `incompressibleVoF` declared **nothing** → the wizard built **zero forms**; the agent had nothing to fill.
- `incompressibleFluidNeoN` was missing the mesh dicts (sweep mesh axis unavailable) and the two mandatory `constant/` files, and never emitted `flux(U)` (the NeoN runtime aborts *Entry 'flux(U)' not found*).

## Changes (schema-only)

All additions are **schema declarations**: `ModelSpec.build_steps` runs only `@build`, so nothing here touches the parity-verified solve path.

**incompressibleVoF** (0 → **14** wizard forms):
- new `configs.py`: two-phase `constant/transportProperties` (`phases` + per-phase `transportModel`/`nu`/`rho` + `sigma`), interFoam `controlDict` (`adjustTimeStep`/`maxCo`/`maxAlphaCo`/`maxDeltaT`), `constant/g`; re-exports `TurbulencePropertiesConfig`
- solver spec binds the `advectionModel` / `PressureVelocityAlgorithm` / optional families and declares controlDict + mesh + transport/g/turbulence configs
- MULES member declares its `0/alpha.water` field + `fvSchemes`/`fvSolution` slices; VoF pimple declares `0/U` + `0/p_rgh` + its `fvSchemes`/`fvSolution` slices

**incompressibleFluidNeoN**:
- declare the mesh dicts (Preprocess / BlockMesh / SnappyHexMesh) so the sweep mesh axis works, and transport/turbulence configs so the two mandatory `constant/` files are surfaced
- add `flux(U)` to the PimpleNeoN `interpolationSchemes`

## Verification

- VoF: full solver suite + damBreak parity **pass**; `build_forms` 0 → 14; the new transport/g/controlDict configs write valid OpenFOAM and read back.
- NeoN: cavity run **passes**; the schema now surfaces the mesh + transport + turbulence forms and `flux(U)`.
- `ruff` + scoped `mypy` clean on the 6 changed files.

## Out of scope

Normalizing agent-written `corrected` → `uncorrected` schemes and `GAMG` → `PCG` solvers for NeoN lives in the compiled `map_fv_*` bindings (a runtime concern), not the solver package.